### PR TITLE
ethernaut-optigov projects task

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethernaut-cli-monorepo",
-  "version": "1.0.0",
+  "version": "1.1.12",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/packages/ethernaut-cli/package.json
+++ b/packages/ethernaut-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethernaut-cli",
-  "version": "1.1.12",
+  "version": "0.0.0",
   "description": "Ai agent cli with web3 capabilities",
   "license": "ISC",
   "author": "Alejandro Santander",

--- a/packages/ethernaut-cli/package.json
+++ b/packages/ethernaut-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethernaut-cli",
-  "version": "0.0.0",
+  "version": "1.1.12",
   "description": "Ai agent cli with web3 capabilities",
   "license": "ISC",
   "author": "Alejandro Santander",

--- a/packages/ethernaut-cli/test/update.test.js
+++ b/packages/ethernaut-cli/test/update.test.js
@@ -2,7 +2,6 @@ const fs = require('fs')
 const storage = require('ethernaut-common/src/io/storage')
 const { Terminal, keys } = require('ethernaut-common/src/test/terminal')
 const assert = require('assert')
-const checkAutoUpdate = require('../src/update')
 
 describe('update', function () {
   let terminal = new Terminal()
@@ -26,7 +25,6 @@ describe('update', function () {
   before('cache', async function () {
     const config = storage.readConfig()
     cachedAutoUpdate = config.general?.autoUpdate
-
     cachedPkg = fs.readFileSync('package.json', 'utf8')
   })
 
@@ -34,24 +32,7 @@ describe('update', function () {
     const config = storage.readConfig()
     config.general.autoUpdate = cachedAutoUpdate
     storage.saveConfig(config)
-
     fs.writeFileSync('package.json', cachedPkg, 'utf8')
-  })
-
-  it('should skip update when autoUpdate matches update version', async function () {
-    // Mock checkUpdate to return a specific version
-    const originalCheckUpdate =
-      require('ethernaut-common/src/util/update').checkUpdate
-    require('ethernaut-common/src/util/update').checkUpdate = () => '1.0.0'
-
-    // Set config to match the update version
-    const config = storage.readConfig()
-    config.general = { autoUpdate: '1.0.0' }
-    storage.saveConfig(config)
-
-    // Restore original function
-    require('ethernaut-common/src/util/update').checkUpdate =
-      originalCheckUpdate
   })
 
   describe('when pkg version is old', function () {
@@ -65,22 +46,6 @@ describe('update', function () {
         JSON.stringify(newConfig, null, 2),
         'utf8',
       )
-    })
-
-    describe('when auto update matches update version', function () {
-      before('modify', async function () {
-        const config = storage.readConfig()
-        config.general = { autoUpdate: '1.0.0' } // Set to the version that will be available
-        storage.saveConfig(config)
-      })
-
-      before('start cli', async function () {
-        await triggerUpdate()
-      })
-
-      it('should not show update prompt', async function () {
-        terminal.notHas('A new version of the ethernaut-cli is available')
-      })
     })
 
     describe('when auto update is never', function () {
@@ -102,6 +67,7 @@ describe('update', function () {
     describe('when auto update is the current version', function () {
       before('modify', async function () {
         const pkg = JSON.parse(cachedPkg)
+        pkg.version = '0.0.0'
         const config = storage.readConfig()
         config.general.autoUpdate = pkg.version
         storage.saveConfig(config)
@@ -112,7 +78,7 @@ describe('update', function () {
       })
 
       it('displays navigation', async function () {
-        terminal.has('Pick a task or scope')
+        terminal.has('A new version of the ethernaut-cli is available')
       })
     })
 
@@ -163,43 +129,6 @@ describe('update', function () {
           it('displays installation', async function () {
             terminal.has('Installing update...')
           })
-
-          it('hides prompts and calls install when installing update', async function () {
-            // Mock the dependencies
-            const originalHidePrompts =
-              require('ethernaut-common/src/ui/prompt').hidePrompts
-            const originalSpawn = require('child_process').spawn
-
-            let hidePromptsCalled = false
-            let spawnCalled = false
-
-            require('ethernaut-common/src/ui/prompt').hidePrompts = (value) => {
-              hidePromptsCalled = value === true
-            }
-
-            require('child_process').spawn = (cmd, args) => {
-              spawnCalled =
-                cmd === 'npm' &&
-                args[0] === 'install' &&
-                args[1] === '-g' &&
-                args[2] === 'ethernaut-cli'
-            }
-
-            // Restore original functions
-            require('ethernaut-common/src/ui/prompt').hidePrompts =
-              originalHidePrompts
-            require('child_process').spawn = originalSpawn
-
-            // Verify the behavior
-            assert(
-              hidePromptsCalled,
-              'hidePrompts should have been called with true',
-            )
-            assert(
-              spawnCalled,
-              'spawn should have been called with npm install command',
-            )
-          })
         })
       })
 
@@ -244,55 +173,6 @@ describe('update', function () {
             const config = storage.readConfig()
             assert.equal(config.general.autoUpdate, 'never')
           })
-        })
-      })
-
-      describe('when autoUpdate matches the available update version', function () {
-        let originalCheckUpdate
-        let originalConsoleLog
-        let consoleOutput = []
-
-        before('mock dependencies', function () {
-          // Guardar implementaciones originales
-          originalCheckUpdate =
-            require('ethernaut-common/src/util/update').checkUpdate
-          originalConsoleLog = console.log
-
-          // Mock checkUpdate
-          require('ethernaut-common/src/util/update').checkUpdate = () =>
-            '1.2.3'
-
-          // Mock console.log
-          console.log = (message) => consoleOutput.push(message)
-
-          // Configurar autoUpdate para que coincida
-          const config = storage.readConfig()
-          config.general = { autoUpdate: '1.2.3' }
-          storage.saveConfig(config)
-        })
-
-        after('restore original implementations', function () {
-          // Restaurar implementaciones originales
-          require('ethernaut-common/src/util/update').checkUpdate =
-            originalCheckUpdate
-          console.log = originalConsoleLog
-        })
-
-        it('should skip the update without showing notice', async function () {
-          // Resetear console output
-          consoleOutput = []
-
-          await checkAutoUpdate({ version: '1.0.0' })
-
-          // Verificar que no se mostró el aviso de actualización
-          const showedUpdateNotice = consoleOutput.some((msg) =>
-            msg.includes('is available, update with'),
-          )
-
-          assert(
-            !showedUpdateNotice,
-            'Update notice should not be shown when version is skipped',
-          )
         })
       })
     })

--- a/packages/ethernaut-cli/test/update.test.js
+++ b/packages/ethernaut-cli/test/update.test.js
@@ -39,10 +39,19 @@ describe('update', function () {
   })
 
   it('should skip update when autoUpdate matches update version', async function () {
-    const pkg = { version: '0.0.0' }
-    const config = { general: { autoUpdate: '1.0.0' } }
+    // Mock checkUpdate to return a specific version
+    const originalCheckUpdate =
+      require('ethernaut-common/src/util/update').checkUpdate
+    require('ethernaut-common/src/util/update').checkUpdate = () => '1.0.0'
+
+    // Set config to match the update version
+    const config = storage.readConfig()
+    config.general = { autoUpdate: '1.0.0' }
     storage.saveConfig(config)
-    await update.checkAutoUpdate(pkg)
+
+    // Restore original function
+    require('ethernaut-common/src/util/update').checkUpdate =
+      originalCheckUpdate
   })
 
   describe('when pkg version is old', function () {
@@ -70,7 +79,7 @@ describe('update', function () {
       })
 
       it('should not show update prompt', async function () {
-        terminal.hasNot('A new version of the ethernaut-cli is available')
+        terminal.notHas('A new version of the ethernaut-cli is available')
       })
     })
 
@@ -175,9 +184,6 @@ describe('update', function () {
                 args[1] === '-g' &&
                 args[2] === 'ethernaut-cli'
             }
-
-            // Call the update function with a mock package
-            await update.checkAutoUpdate({ version: '0.0.0' })
 
             // Restore original functions
             require('ethernaut-common/src/ui/prompt').hidePrompts =

--- a/packages/ethernaut-optigov/src/internal/agora/Agora.js
+++ b/packages/ethernaut-optigov/src/internal/agora/Agora.js
@@ -1,0 +1,35 @@
+const axios = require('axios')
+const debug = require('ethernaut-common/src/ui/debug')
+const EthernautCliError = require('ethernaut-common/src/error/error')
+const Auth = require('./Auth')
+const Projects = require('./Projects')
+
+const API_BASE_URL = 'https://vote.optimism.io/api/v1'
+const AGORA_API_KEY = process.env.AGORA_API_KEY
+
+class Agora {
+  constructor() {
+    this.auth = new Auth(this)
+    this.projects = new Projects(this)
+  }
+
+  async getSpec() {
+    try {
+      const response = await axios.get(`${API_BASE_URL}/spec`, {
+        headers: {
+          Authorization: `Bearer ${AGORA_API_KEY}`,
+        },
+      })
+
+      debug.log(`Spec: ${response.data}`, 'ethernaut-optigov')
+      return response.data
+    } catch (error) {
+      throw new EthernautCliError(
+        'ethernaut-optigov',
+        `Http status error: ${error.message}`,
+      )
+    }
+  }
+}
+
+module.exports = Agora

--- a/packages/ethernaut-optigov/src/internal/agora/Agora.js
+++ b/packages/ethernaut-optigov/src/internal/agora/Agora.js
@@ -1,34 +1,61 @@
 const axios = require('axios')
-const debug = require('ethernaut-common/src/ui/debug')
 const EthernautCliError = require('ethernaut-common/src/error/error')
-const Auth = require('./Auth')
-const Projects = require('./Projects')
+const debug = require('ethernaut-common/src/ui/debug')
 
 const API_BASE_URL = 'https://vote.optimism.io/api/v1'
 const AGORA_API_KEY = process.env.AGORA_API_KEY
 
 class Agora {
   constructor() {
-    this.auth = new Auth(this)
-    this.projects = new Projects(this)
+    this.apiKey = AGORA_API_KEY
+    this.apiBaseUrl = API_BASE_URL
+    this.bearerToken = null
   }
 
-  async getSpec() {
-    try {
-      const response = await axios.get(`${API_BASE_URL}/spec`, {
-        headers: {
-          Authorization: `Bearer ${AGORA_API_KEY}`,
-        },
-      })
+  // Axios instance setup
+  createAxiosInstance() {
+    const headers = {
+      Authorization: this.bearerToken
+        ? `Bearer ${this.bearerToken}`
+        : `Bearer ${this.apiKey}`,
+    }
 
-      debug.log(`Spec: ${response.data}`, 'ethernaut-optigov')
-      return response.data
-    } catch (error) {
+    return axios.create({
+      baseURL: this.apiBaseUrl,
+      headers,
+    })
+  }
+
+  // Handle common API errors
+  handleError(error) {
+    if (error.response) {
+      throw new EthernautCliError(
+        'ethernaut-optigov',
+        `Http status error: ${error.response.data}`,
+      )
+    } else {
       throw new EthernautCliError(
         'ethernaut-optigov',
         `Http status error: ${error.message}`,
       )
     }
+  }
+
+  // common method for getting API spec
+  async getSpec() {
+    try {
+      const axiosInstance = this.createAxiosInstance()
+      const response = await axiosInstance.get('/spec')
+      debug.log(`Spec: ${response.data}`, 'ethernaut-optigov')
+      return response.data
+    } catch (error) {
+      this.handleError(error)
+    }
+  }
+
+  // Set the bearer token after authentication
+  setBearerToken(token) {
+    this.bearerToken = token
   }
 }
 

--- a/packages/ethernaut-optigov/src/internal/agora/Auth.js
+++ b/packages/ethernaut-optigov/src/internal/agora/Auth.js
@@ -1,15 +1,16 @@
 const axios = require('axios')
 const debug = require('ethernaut-common/src/ui/debug')
 const EthernautCliError = require('ethernaut-common/src/error/error')
-const API_BASE_URL = 'https://vote.optimism.io/api/v1'
 
 class Auth {
-  constructor() {}
+  constructor(agora) {
+    this.agora = agora
+  }
 
   // Get a nonce from the Agora API
   async getNonce() {
     try {
-      const response = await axios.get(`${API_BASE_URL}/auth/nonce`)
+      const response = await axios.get(`${this.agora.API_BASE_URL}/auth/nonce`)
 
       debug.log(`Nonce: ${response.data.nonce}`, 'ethernaut-optigov')
       return response.data
@@ -25,7 +26,7 @@ class Auth {
   async authenticateWithAgora(message, signature, nonce) {
     try {
       const response = await axios.post(
-        `${API_BASE_URL}/auth/verify`,
+        `${this.agora.API_BASE_URL}/auth/verify`,
         {
           message,
           signature,

--- a/packages/ethernaut-optigov/src/internal/agora/Auth.js
+++ b/packages/ethernaut-optigov/src/internal/agora/Auth.js
@@ -1,62 +1,38 @@
-const axios = require('axios')
 const debug = require('ethernaut-common/src/ui/debug')
-const EthernautCliError = require('ethernaut-common/src/error/error')
 
 class Auth {
   constructor(agora) {
     this.agora = agora
   }
 
-  // Get a nonce from the Agora API
   async getNonce() {
     try {
-      const response = await axios.get(`${this.agora.API_BASE_URL}/auth/nonce`)
-
+      const axiosInstance = this.agora.createAxiosInstance()
+      const response = await axiosInstance.get('/auth/nonce')
       debug.log(`Nonce: ${response.data.nonce}`, 'ethernaut-optigov')
-      return response.data
+      return response.data.nonce
     } catch (error) {
-      throw new EthernautCliError(
-        'ethernaut-optigov',
-        `Http status error: ${error.message}`,
-      )
+      this.agora.handleError(error)
     }
   }
 
-  // Authenticate with the Agora API
   async authenticateWithAgora(message, signature, nonce) {
     try {
-      const response = await axios.post(
-        `${this.agora.API_BASE_URL}/auth/verify`,
-        {
-          message,
-          signature,
-          nonce,
-        },
-        {
-          headers: {
-            'Content-Type': 'application/json',
-          },
-        },
-      )
+      const axiosInstance = this.agora.createAxiosInstance()
+      const response = await axiosInstance.post('/auth/verify', {
+        message,
+        signature,
+        nonce,
+      })
 
       debug.log('Auth Response Status:', response.status)
-      // save the Bearer token
-      this.bearerToken = response.data.access_token
+
+      // Set the Bearer token for future requests
+      this.agora.setBearerToken(response.data.access_token)
+
       return response.data.access_token
     } catch (error) {
-      if (error.response) {
-        // Server responded with a status other than 2xx
-        throw new EthernautCliError(
-          'ethernaut-optigov',
-          `Http status error: ${error.response.data}`,
-        )
-      } else {
-        // Other errors (e.g., network issue)
-        throw new EthernautCliError(
-          'ethernaut-optigov',
-          `Http status error: ${error.message}`,
-        )
-      }
+      this.agora.handleError(error)
     }
   }
 }

--- a/packages/ethernaut-optigov/src/internal/agora/Projects.js
+++ b/packages/ethernaut-optigov/src/internal/agora/Projects.js
@@ -1,29 +1,29 @@
 const axios = require('axios')
-// const debug = require('ethernaut-common/src/ui/debug')
+const debug = require('ethernaut-common/src/ui/debug')
 const EthernautCliError = require('ethernaut-common/src/error/error')
-const API_BASE_URL = 'https://vote.optimism.io/api/v1'
 
 class Projects {
-  // constructor(agora) {
-  //   this.agora = agora
-  // }
+  constructor(agora) {
+    this.agora = agora
+  }
 
-  constructor() {
-    this.apiKey = process.env.AGORA_API_KEY
+  async getLatestRound() {
+    // TODO: Implement this
+    return 5
   }
 
   async projects({ limit, offset } = { limit: 10, offset: 0 }) {
     try {
       const response = await axios.get(
-        `${API_BASE_URL}/projects?limit=${limit}&?offset=${offset}`,
+        `${this.agora.API_BASE_URL}/projects?limit=${limit}&?offset=${offset}`,
         {
           headers: {
-            Authorization: `Bearer ${this.apiKey}`,
+            Authorization: `Bearer ${this.agora.AGORA_API_KEY}`,
           },
         },
       )
 
-      // debug.log(`Nonce: ${response.data.nonce}`, 'ethernaut-optigov')
+      debug.log(`Projects: ${response.data}`, 'ethernaut-optigov')
       return response.data.data
     } catch (error) {
       throw new EthernautCliError(
@@ -36,7 +36,7 @@ class Projects {
   async roundProjects({ roundId, limit = 10, offset = 0 }) {
     try {
       const response = await axios.get(
-        `${API_BASE_URL}/retrofunding/rounds/${roundId}/projects?limit=${limit}&offset=${offset}`,
+        `${this.agora.API_BASE_URL}/retrofunding/rounds/${roundId}/projects?limit=${limit}&offset=${offset}`,
         {
           headers: {
             Authorization: `Bearer ${this.apiKey}`,
@@ -44,8 +44,7 @@ class Projects {
         },
       )
 
-      // debug.log(`Nonce: ${response.data.nonce}`, 'ethernaut-optigov')
-      // console.log('roundProjects: ', response.data)
+      debug.log(`Round Projects: ${response.data}`, 'ethernaut-optigov')
       return response.data.data
     } catch (error) {
       throw new EthernautCliError(

--- a/packages/ethernaut-optigov/src/internal/agora/Projects.js
+++ b/packages/ethernaut-optigov/src/internal/agora/Projects.js
@@ -1,0 +1,59 @@
+const axios = require('axios')
+// const debug = require('ethernaut-common/src/ui/debug')
+const EthernautCliError = require('ethernaut-common/src/error/error')
+const API_BASE_URL = 'https://vote.optimism.io/api/v1'
+
+class Projects {
+  // constructor(agora) {
+  //   this.agora = agora
+  // }
+
+  constructor() {
+    this.apiKey = process.env.AGORA_API_KEY
+  }
+
+  async projects({ limit, offset } = { limit: 10, offset: 0 }) {
+    try {
+      const response = await axios.get(
+        `${API_BASE_URL}/projects?limit=${limit}&?offset=${offset}`,
+        {
+          headers: {
+            Authorization: `Bearer ${this.apiKey}`,
+          },
+        },
+      )
+
+      // debug.log(`Nonce: ${response.data.nonce}`, 'ethernaut-optigov')
+      return response.data.data
+    } catch (error) {
+      throw new EthernautCliError(
+        'ethernaut-optigov',
+        `Http status error: ${error.message}`,
+      )
+    }
+  }
+
+  async roundProjects({ roundId, limit = 10, offset = 0 }) {
+    try {
+      const response = await axios.get(
+        `${API_BASE_URL}/retrofunding/rounds/${roundId}/projects?limit=${limit}&offset=${offset}`,
+        {
+          headers: {
+            Authorization: `Bearer ${this.apiKey}`,
+          },
+        },
+      )
+
+      // debug.log(`Nonce: ${response.data.nonce}`, 'ethernaut-optigov')
+      // console.log('roundProjects: ', response.data)
+      return response.data.data
+    } catch (error) {
+      throw new EthernautCliError(
+        'ethernaut-optigov',
+        `Http status error: ${error.message}`,
+      )
+    }
+  }
+}
+
+module.exports = Projects

--- a/packages/ethernaut-optigov/src/internal/agora/Projects.js
+++ b/packages/ethernaut-optigov/src/internal/agora/Projects.js
@@ -1,6 +1,4 @@
-const axios = require('axios')
 const debug = require('ethernaut-common/src/ui/debug')
-const EthernautCliError = require('ethernaut-common/src/error/error')
 
 class Projects {
   constructor(agora) {
@@ -8,49 +6,37 @@ class Projects {
   }
 
   async getLatestRound() {
-    // TODO: Implement this
-    return 5
+    return 5 // Placeholder, you can implement this logic
   }
 
-  async projects({ limit, offset } = { limit: 10, offset: 0 }) {
+  async getProjects({ limit = 10, offset = 0 } = {}) {
     try {
-      const response = await axios.get(
-        `${this.agora.API_BASE_URL}/projects?limit=${limit}&?offset=${offset}`,
-        {
-          headers: {
-            Authorization: `Bearer ${this.agora.AGORA_API_KEY}`,
-          },
-        },
-      )
+      const axiosInstance = this.agora.createAxiosInstance()
+      const response = await axiosInstance.get('/projects', {
+        params: { limit, offset },
+      })
 
       debug.log(`Projects: ${response.data}`, 'ethernaut-optigov')
       return response.data.data
     } catch (error) {
-      throw new EthernautCliError(
-        'ethernaut-optigov',
-        `Http status error: ${error.message}`,
-      )
+      this.agora.handleError(error)
     }
   }
 
-  async roundProjects({ roundId, limit = 10, offset = 0 }) {
+  async getRoundProjects({ roundId, limit = 10, offset = 0 }) {
     try {
-      const response = await axios.get(
-        `${this.agora.API_BASE_URL}/retrofunding/rounds/${roundId}/projects?limit=${limit}&offset=${offset}`,
+      const axiosInstance = this.agora.createAxiosInstance()
+      const response = await axiosInstance.get(
+        `/retrofunding/rounds/${roundId}/projects`,
         {
-          headers: {
-            Authorization: `Bearer ${this.apiKey}`,
-          },
+          params: { limit, offset },
         },
       )
 
       debug.log(`Round Projects: ${response.data}`, 'ethernaut-optigov')
       return response.data.data
     } catch (error) {
-      throw new EthernautCliError(
-        'ethernaut-optigov',
-        `Http status error: ${error.message}`,
-      )
+      this.agora.handleError(error)
     }
   }
 }

--- a/packages/ethernaut-optigov/src/tasks/Projects.js
+++ b/packages/ethernaut-optigov/src/tasks/Projects.js
@@ -1,8 +1,6 @@
 const types = require('ethernaut-common/src/validation/types')
 const output = require('ethernaut-common/src/ui/output')
-const Projects = require('../internal/agora/Projects')
-// const Agora = require('../internal/agora/Agora')
-// const { getLatestRound } = require('../internal/agora/utils/latest-round')
+const Agora = require('../internal/agora/Agora')
 
 require('../scopes/optigov')
   .task(
@@ -28,15 +26,14 @@ require('../scopes/optigov')
     types.string,
   )
   .setAction(async ({ round, name, category }) => {
-    console.log('params: ', { round, name, category })
-
     try {
+      const agora = new Agora()
+
       let roundId
-      if (round === 'latest')
-        roundId = 5 // await getLatestRound()
+      if (round === 'latest') roundId = agora.projects.getLatestRound()
       else if (round === 'any') roundId = undefined
 
-      let projects = await getProjects(roundId)
+      let projects = await getProjects(agora, roundId)
 
       projects = filterProjects(projects, name, category)
 
@@ -75,22 +72,10 @@ function printProjects(projects) {
   return strs.join('\n\n')
 }
 
-async function getProjects(roundId) {
-  const agora = new Projects()
-
+async function getProjects(agora, roundId) {
   if (roundId === undefined) {
-    return await agora.projects()
+    return await agora.projects.projects()
   }
 
-  return await agora.roundProjects({ roundId })
+  return await agora.projects.roundProjects({ roundId })
 }
-
-// async function getProjects(roundId) {
-//   const agora = new Agora()
-
-//   if (roundId === 'any') {
-//     return await agora.retro.projects()
-//   }
-
-//   return await agora.retro.roundProjects({ roundId })
-// }

--- a/packages/ethernaut-optigov/src/tasks/Projects.js
+++ b/packages/ethernaut-optigov/src/tasks/Projects.js
@@ -1,0 +1,96 @@
+const types = require('ethernaut-common/src/validation/types')
+const output = require('ethernaut-common/src/ui/output')
+const Projects = require('../internal/agora/Projects')
+// const Agora = require('../internal/agora/Agora')
+// const { getLatestRound } = require('../internal/agora/utils/latest-round')
+
+require('../scopes/optigov')
+  .task(
+    'projects',
+    'Prints a list of projects registered in RetroPGF, given specified filters',
+  )
+  .addParam(
+    'round',
+    'The round number to query. Defaults to "latest". Can also be "any" to query all rounds.',
+    'latest',
+    types.string,
+  )
+  .addOptionalParam(
+    'name',
+    'A filter to apply to the project names',
+    undefined,
+    types.string,
+  )
+  .addOptionalParam(
+    'category',
+    'A filter to apply to the project category',
+    undefined,
+    types.string,
+  )
+  .setAction(async ({ round, name, category }) => {
+    console.log('params: ', { round, name, category })
+
+    try {
+      let roundId
+      if (round === 'latest')
+        roundId = 5 // await getLatestRound()
+      else if (round === 'any') roundId = undefined
+
+      let projects = await getProjects(roundId)
+
+      projects = filterProjects(projects, name, category)
+
+      return output.resultBox(printProjects(projects), 'Projects')
+    } catch (err) {
+      return output.errorBox(err)
+    }
+  })
+
+function filterProjects(projects, name, category) {
+  const nameLower = name?.toLowerCase()
+  const categoryLower = category?.toLowerCase()
+
+  return projects.filter((p) => {
+    // Filter by name if it's provided
+    const matchesName = nameLower
+      ? p.name.toLowerCase().includes(nameLower)
+      : true
+
+    // Filter by category if it's provided
+    const matchesCategory = categoryLower
+      ? p.category.toLowerCase() === categoryLower
+      : true
+
+    return matchesName && matchesCategory
+  })
+}
+
+function printProjects(projects) {
+  const strs = []
+
+  for (const project of projects) {
+    strs.push(` - ${project.name}: ${project.category}: ${project.description}`)
+  }
+
+  return strs.join('\n\n')
+}
+
+async function getProjects(roundId) {
+  const agora = new Projects()
+
+  if (roundId === undefined) {
+    return await agora.projects()
+  }
+
+  return await agora.roundProjects({ roundId })
+}
+
+// async function getProjects(roundId) {
+//   const agora = new Agora()
+
+//   if (roundId === 'any') {
+//     return await agora.retro.projects()
+//   }
+
+//   return await agora.retro.roundProjects({ roundId })
+// }

--- a/packages/ethernaut-optigov/src/tasks/Projects.js
+++ b/packages/ethernaut-optigov/src/tasks/Projects.js
@@ -8,6 +8,18 @@ require('../scopes/optigov')
     'projects',
     'Prints a list of projects registered in RetroPGF, given specified filters',
   )
+  .addOptionalParam(
+    'limit',
+    'The maximum number of proposals to fetch. Defaults to 10.',
+    10,
+    types.int,
+  )
+  .addOptionalParam(
+    'offset',
+    'The number of proposals to skip before starting to fetch. Defaults to 0.',
+    0,
+    types.int,
+  )
   .addParam(
     'round',
     'The round number to query. Defaults to "latest". Can also be "any" to query all rounds.',
@@ -26,9 +38,9 @@ require('../scopes/optigov')
     undefined,
     types.string,
   )
-  .setAction(async ({ round, name, category }) => {
+  .setAction(async ({ limit, offset, round, name, category }) => {
     try {
-      const projects = await getProjects(round)
+      const projects = await getProjects(limit, offset, round)
 
       const filteredProjects = filterProjects(projects, name, category)
 
@@ -67,7 +79,7 @@ function printProjects(projects) {
   return strs.join('\n\n')
 }
 
-async function getProjects(round) {
+async function getProjects(limit, offset, round) {
   const agora = new Agora()
   const projects = new Projects(agora)
 
@@ -78,8 +90,8 @@ async function getProjects(round) {
   }
 
   if (!roundId) {
-    return await projects.getProjects()
+    return await projects.getProjects(limit, offset)
   }
 
-  return await projects.getRoundProjects({ roundId })
+  return await projects.getRoundProjects({ roundId, limit, offset })
 }

--- a/packages/ethernaut-optigov/src/tasks/login.js
+++ b/packages/ethernaut-optigov/src/tasks/login.js
@@ -1,7 +1,8 @@
-const Auth = require('../internal/agora/Auth')
 const output = require('ethernaut-common/src/ui/output')
 const { createSiweMessage } = require('../internal/Siwe')
 const EthernautCliError = require('ethernaut-common/src/error/error')
+const Auth = require('../internal/agora/Auth')
+const Agora = require('../internal/agora/Agora')
 
 require('../scopes/optigov')
   .task(
@@ -24,7 +25,8 @@ require('../scopes/optigov')
         'ethernaut-optigov',
       )
 
-      const auth = new Auth()
+      const agora = new Agora()
+      const auth = new Auth(agora)
 
       const statement = 'Log in to Agoras RetroPGF API with SIWE.'
       const nonce = await auth.getNonce()

--- a/packages/ethernaut-optigov/test/internal/agora/Agora.test.js
+++ b/packages/ethernaut-optigov/test/internal/agora/Agora.test.js
@@ -1,0 +1,82 @@
+const assert = require('assert')
+const axios = require('axios')
+const Agora = require('../../../src/internal/agora/Agora')
+
+describe('Agora Module', function () {
+  let agora, fakeAxiosInstance
+
+  beforeEach(function () {
+    // Create a fresh Agora instance for each test.
+    agora = new Agora()
+
+    // Default fake axios instance that returns a spec
+    fakeAxiosInstance = {
+      get: async (path, _config) => {
+        if (path === '/spec') {
+          // Return spec normally unless overridden in a test
+          return { data: { spec: 'fake_spec' } }
+        }
+      },
+    }
+
+    // Override createAxiosInstance to use the fake axios instance
+    agora.createAxiosInstance = () => fakeAxiosInstance
+  })
+
+  it('should perform its primary operation by getting the API spec', async function () {
+    const spec = await agora.getSpec()
+    assert.deepEqual(spec, { spec: 'fake_spec' })
+  })
+
+  it('should throw an error with response data when getSpec fails with error.response', async function () {
+    // Override fakeAxiosInstance.get to throw an error with a response property.
+    fakeAxiosInstance.get = async () => {
+      throw { response: { data: 'error_data' } }
+    }
+    agora.createAxiosInstance = () => fakeAxiosInstance
+
+    try {
+      await agora.getSpec()
+      assert.fail('Expected error was not thrown')
+    } catch (err) {
+      // Now expecting HardhatPluginError instead of EthernautCliError
+      assert.strictEqual(err.constructor.name, 'HardhatPluginError')
+      assert.strictEqual(err.message, 'Http status error: error_data')
+    }
+  })
+
+  it('should throw an error with error.message when getSpec fails without error.response', async function () {
+    // Override fakeAxiosInstance.get to throw an error without response property.
+    fakeAxiosInstance.get = async () => {
+      throw { message: 'some error' }
+    }
+    agora.createAxiosInstance = () => fakeAxiosInstance
+
+    try {
+      await agora.getSpec()
+      assert.fail('Expected error was not thrown')
+    } catch (err) {
+      assert.strictEqual(err.constructor.name, 'HardhatPluginError')
+      assert.strictEqual(err.message, 'Http status error: some error')
+    }
+  })
+
+  it('should include bearerToken in Authorization header if set', function () {
+    // Set a bearer token on the Agora instance.
+    agora.setBearerToken('my_bearer_token')
+
+    // Simulate axios.create with the current token.
+    const instance = axios.create({
+      baseURL: agora.apiBaseUrl,
+      headers: {
+        Authorization: `Bearer ${agora.bearerToken}`,
+      },
+    })
+
+    // Assert that the Authorization header is set correctly.
+    assert.strictEqual(
+      instance.defaults.headers.Authorization,
+      'Bearer my_bearer_token',
+    )
+  })
+})

--- a/packages/ethernaut-optigov/test/internal/agora/Auth.test.js
+++ b/packages/ethernaut-optigov/test/internal/agora/Auth.test.js
@@ -2,9 +2,7 @@ const assert = require('assert')
 const Auth = require('../../../src/internal/agora/Auth')
 
 describe('Auth Module', function () {
-  let auth
-  let mockAgora
-  let axiosInstance
+  let auth, mockAgora, axiosInstance
 
   beforeEach(function () {
     // Create a fake axios instance
@@ -21,14 +19,15 @@ describe('Auth Module', function () {
       },
     }
 
-    // Create a mock agora with required methods
+    // Create a mock agora with required methods.
+    // For failure cases, we rely on handleError to rethrow the error.
     mockAgora = {
       createAxiosInstance: () => axiosInstance,
       handleError: (error) => {
         throw error
       },
       setBearerToken: (_token) => {
-        // Mock implementation (could store token if needed)
+        // Optionally store the token if needed.
       },
     }
 
@@ -40,6 +39,23 @@ describe('Auth Module', function () {
       const nonce = await auth.getNonce()
       assert.equal(nonce, 'fake_nonce')
     })
+
+    it('should propagate error when getNonce fails', async function () {
+      // Simulate failure by overriding get to throw an error.
+      axiosInstance.get = async () => {
+        throw { message: 'nonce error' }
+      }
+      // Reassign the axios instance.
+      mockAgora.createAxiosInstance = () => axiosInstance
+
+      try {
+        await auth.getNonce()
+        assert.fail('Expected error was not thrown')
+      } catch (err) {
+        // Since handleError just rethrows, the error should propagate.
+        assert.strictEqual(err.message, 'nonce error')
+      }
+    })
   })
 
   describe('authenticateWithAgora', function () {
@@ -50,6 +66,23 @@ describe('Auth Module', function () {
         'dummy_nonce',
       )
       assert.equal(token, 'fake_token')
+    })
+
+    it('should propagate error when authenticateWithAgora fails', async function () {
+      // Simulate failure by overriding post to throw an error.
+      axiosInstance.post = async () => {
+        throw { message: 'auth error' }
+      }
+      // Reassign the axios instance.
+      mockAgora.createAxiosInstance = () => axiosInstance
+
+      try {
+        await auth.authenticateWithAgora('msg', 'sig', 'nonce')
+        assert.fail('Expected error was not thrown')
+      } catch (err) {
+        // Since handleError just rethrows, the error should propagate.
+        assert.strictEqual(err.message, 'auth error')
+      }
     })
   })
 })

--- a/packages/ethernaut-optigov/test/internal/agora/Auth.test.js
+++ b/packages/ethernaut-optigov/test/internal/agora/Auth.test.js
@@ -1,0 +1,55 @@
+const assert = require('assert')
+const Auth = require('../../../src/internal/agora/Auth')
+
+describe('Auth Module', function () {
+  let auth
+  let mockAgora
+  let axiosInstance
+
+  beforeEach(function () {
+    // Create a fake axios instance
+    axiosInstance = {
+      get: async (path) => {
+        if (path === '/auth/nonce') {
+          return { data: { nonce: 'fake_nonce' } }
+        }
+      },
+      post: async (path, _payload) => {
+        if (path === '/auth/verify') {
+          return { status: 200, data: { access_token: 'fake_token' } }
+        }
+      },
+    }
+
+    // Create a mock agora with required methods
+    mockAgora = {
+      createAxiosInstance: () => axiosInstance,
+      handleError: (error) => {
+        throw error
+      },
+      setBearerToken: (_token) => {
+        // Mock implementation (could store token if needed)
+      },
+    }
+
+    auth = new Auth(mockAgora)
+  })
+
+  describe('getNonce', function () {
+    it('should return a valid nonce string', async function () {
+      const nonce = await auth.getNonce()
+      assert.equal(nonce, 'fake_nonce')
+    })
+  })
+
+  describe('authenticateWithAgora', function () {
+    it('should return an access token for valid inputs', async function () {
+      const token = await auth.authenticateWithAgora(
+        'dummy_message',
+        'dummy_signature',
+        'dummy_nonce',
+      )
+      assert.equal(token, 'fake_token')
+    })
+  })
+})

--- a/packages/ethernaut-optigov/test/internal/agora/Projects.test.js
+++ b/packages/ethernaut-optigov/test/internal/agora/Projects.test.js
@@ -1,0 +1,50 @@
+// filepath: /Users/luisvidela/Development/EthernautCLI/ethernaut-cli/test/internal/agora/Projects.test.js
+const assert = require('assert')
+const Projects = require('../../../src/internal/agora/Projects')
+
+describe('Projects Module', function () {
+  let projects, mockAgora, axiosInstance
+
+  beforeEach(function () {
+    // Setup a mock agora with a fake axios instance
+    axiosInstance = {
+      get: async (url, { params } = {}) => {
+        if (url === '/projects') {
+          return { data: { data: { projects: ['project1'], params } } }
+        }
+        if (url.startsWith('/retrofunding/rounds/')) {
+          return { data: { data: { projects: ['roundProject'] } } }
+        }
+      },
+    }
+    mockAgora = {
+      createAxiosInstance: () => axiosInstance,
+      handleError: (error) => {
+        throw error
+      },
+    }
+    projects = new Projects(mockAgora)
+  })
+
+  it('should return project details from getProjects', async function () {
+    const result = await projects.getProjects({ limit: 5, offset: 0 })
+    assert.deepEqual(result, {
+      projects: ['project1'],
+      params: { limit: 5, offset: 0 },
+    })
+  })
+
+  it('should return round projects from getRoundProjects', async function () {
+    const result = await projects.getRoundProjects({
+      roundId: 1,
+      limit: 5,
+      offset: 0,
+    })
+    assert.deepEqual(result, { projects: ['roundProject'] })
+  })
+
+  it('should return the latest round as 5', async function () {
+    const latestRound = await projects.getLatestRound()
+    assert.equal(latestRound, 5)
+  })
+})

--- a/packages/ethernaut-optigov/test/internal/agora/Projects.test.js
+++ b/packages/ethernaut-optigov/test/internal/agora/Projects.test.js
@@ -19,6 +19,7 @@ describe('Projects Module', function () {
     }
     mockAgora = {
       createAxiosInstance: () => axiosInstance,
+      // For failure tests, handleError just rethrows the error.
       handleError: (error) => {
         throw error
       },
@@ -46,5 +47,35 @@ describe('Projects Module', function () {
   it('should return the latest round as 5', async function () {
     const latestRound = await projects.getLatestRound()
     assert.equal(latestRound, 5)
+  })
+
+  it('should propagate error when getProjects fails', async function () {
+    // Override axiosInstance.get to throw an error.
+    axiosInstance.get = async () => {
+      throw { message: 'projects error' }
+    }
+    mockAgora.createAxiosInstance = () => axiosInstance
+
+    try {
+      await projects.getProjects({ limit: 5, offset: 0 })
+      assert.fail('Expected error was not thrown')
+    } catch (err) {
+      assert.strictEqual(err.message, 'projects error')
+    }
+  })
+
+  it('should propagate error when getRoundProjects fails', async function () {
+    // Override axiosInstance.get to throw an error.
+    axiosInstance.get = async () => {
+      throw { message: 'round projects error' }
+    }
+    mockAgora.createAxiosInstance = () => axiosInstance
+
+    try {
+      await projects.getRoundProjects({ roundId: 1, limit: 5, offset: 0 })
+      assert.fail('Expected error was not thrown')
+    } catch (err) {
+      assert.strictEqual(err.message, 'round projects error')
+    }
   })
 })

--- a/packages/ethernaut-optigov/test/tasks/projects.test.js
+++ b/packages/ethernaut-optigov/test/tasks/projects.test.js
@@ -1,0 +1,123 @@
+const assert = require('assert')
+const Projects = require('../../src/internal/agora/Projects')
+const hre = require('hardhat')
+const output = require('ethernaut-common/src/ui/output')
+
+describe('projects task', function () {
+  let originalGetProjects,
+    originalGetRoundProjects,
+    originalGetLatestRound,
+    originalOutputResultBox,
+    originalOutputErrorBox
+
+  beforeEach(function () {
+    // Mock Projects class methods
+    originalGetProjects = Projects.prototype.getProjects
+    originalGetRoundProjects = Projects.prototype.getRoundProjects
+    originalGetLatestRound = Projects.prototype.getLatestRound
+
+    Projects.prototype.getProjects = async function ({
+      limit: _limit,
+      offset: _offset,
+    }) {
+      return [
+        {
+          name: 'Project 1',
+          category: 'Category A',
+          description: 'Description 1',
+        },
+        {
+          name: 'Project 2',
+          category: 'Category B',
+          description: 'Description 2',
+        },
+      ]
+    }
+
+    Projects.prototype.getRoundProjects = async function ({
+      roundId,
+      limit: _limit,
+      offset: _offset,
+    }) {
+      return [
+        {
+          name: `Project for Round ${roundId}`,
+          category: 'Category A',
+          description: 'Description for round project',
+        },
+      ]
+    }
+
+    Projects.prototype.getLatestRound = async function () {
+      return 5
+    }
+
+    // Mock the output methods
+    originalOutputResultBox = output.resultBox
+    originalOutputErrorBox = output.errorBox
+
+    output.resultBox = (content, title) => `${title}: ${content}`
+    output.errorBox = (error) => `Error: ${error.message}`
+  })
+
+  afterEach(function () {
+    // Restore the original methods after each test
+    Projects.prototype.getProjects = originalGetProjects
+    Projects.prototype.getRoundProjects = originalGetRoundProjects
+    Projects.prototype.getLatestRound = originalGetLatestRound
+
+    output.resultBox = originalOutputResultBox
+    output.errorBox = originalOutputErrorBox
+  })
+
+  it('fetches a list of projects with limit and offset', async function () {
+    const result = await hre.run(
+      { scope: 'optigov', task: 'projects' },
+      { limit: 2, offset: 0, round: 'any' },
+    )
+    assert.equal(
+      result,
+      'Projects:  - Project 1: Category A: Description 1\n\n - Project 2: Category B: Description 2',
+    )
+  })
+
+  it('fetches projects for the latest round', async function () {
+    const result = await hre.run(
+      { scope: 'optigov', task: 'projects' },
+      { round: 'latest', limit: 2, offset: 0 },
+    )
+
+    assert.equal(
+      result,
+      'Projects:  - Project for Round 5: Category A: Description for round project',
+    )
+  })
+
+  it('fetches projects filtered by name and category', async function () {
+    const result = await hre.run(
+      { scope: 'optigov', task: 'projects' },
+      {
+        round: 'any',
+        limit: 2,
+        offset: 0,
+        name: 'Project 1',
+        category: 'Category A',
+      },
+    )
+
+    assert.equal(result, 'Projects:  - Project 1: Category A: Description 1')
+  })
+
+  it('handles errors gracefully when fetching projects fails', async function () {
+    Projects.prototype.getProjects = async function () {
+      throw new Error('Failed to fetch projects')
+    }
+
+    const result = await hre.run(
+      { scope: 'optigov', task: 'projects' },
+      { limit: 2, offset: 0, round: 'any' },
+    )
+
+    assert.equal(result, 'Error: Failed to fetch projects')
+  })
+})


### PR DESCRIPTION
### Summary

This PR introduces a new **projects** task to retrieve data related to RetroPGF Projects. The command allows filtering by project category, name, and round, providing detailed information about each project.

### Usage

You can use the following commands to retrieve project data:

```bash
$ ethernaut optigov projects [--category <STRING>] [--name <STRING>] [--round <STRING>] [--limit <INT>] [--offset <INT>]
```

Examples:
- Get projects in the "Utility" category:
  ```bash
  $ ethernaut optigov projects --category Utility
  ```
  
- Get project details by name:
  ```bash
  $ ethernaut optigov projects --name libp2p
  ```

- Filter projects by both name and category:
  ```bash
  $ ethernaut optigov projects --name libp2p --category Utility
  ```

- Retrieve projects from the latest round in a specific category:
  ```bash
  $ ethernaut optigov projects --category Utility --round latest
  ```

### Example Output

```
Usage: optigov projects [--category <STRING>] [--name <STRING>] [--round <STRING>] [--limit <INT>] [--offset <INT>]

╭ Projects ──╮
│ - Rust Libp2p: Utility: The Rust implementation of libp2p. Libp2p is a modular framework for various p2p protocols. These protocols are widely used by many projects to establish decentralized p2p communications. 
│   
│   Notable projects using Rust Libp2p include Magi (OP Stack rollup client), Lighthouse (Ethereum consensus client), and Forest (Filecoin client).
│ 
│ - Rollup-as-a-Service Platform: Utility: Launch enterprise-grade L2 & L3 chains integrated with industry-standard Web3 services in just 1-click! 
│   
│   Gelato powers several OP chains, including some in stealth mode, enabling over 19.5M transactions within just a few months.
╰────────────╯
```
