### PR TITLE
ethernaut-optigov delegates task 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,27 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           flag-name: ethernaut-oso
           parallel: true
+  ethernaut-optigov:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: ['20.12.0']
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm ci
+      - run: npm run build --if-present
+      - run: npm run compile --if-present
+      - run: cd packages/ethernaut-optigov && npm t
+      - name: Coveralls
+        uses: coverallsapp/github-action@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          flag-name: ethernaut-optigov
+          parallel: true
   ethernaut-util:
     runs-on: ubuntu-latest
     strategy:
@@ -384,6 +405,7 @@ jobs:
       - lint
       - ethernaut-common
       - ethernaut-oso
+      - ethernaut-optigov
       - ethernaut-util
       - ethernaut-util-ui
       - ethernaut-ui
@@ -404,4 +426,4 @@ jobs:
         uses: coverallsapp/github-action@v2
         with:
           parallel-finished: true
-          carryforward: 'lint,ethernaut-common,ethernaut-oso,ethernaut-util,ethernaut-util-ui,ethernaut-ui,ethernaut-interact,ethernaut-interact-ui,ethernaut-challenges,ethernaut-ai,ethernaut-ai-ui,ethernaut-network,ethernaut-network-ui,ethernaut-wallet,ethernaut-wallet-ui,ethernaut-cli'
+          carryforward: 'lint,ethernaut-common,ethernaut-oso,ethernaut-optigov,ethernaut-util,ethernaut-util-ui,ethernaut-ui,ethernaut-interact,ethernaut-interact-ui,ethernaut-challenges,ethernaut-ai,ethernaut-ai-ui,ethernaut-network,ethernaut-network-ui,ethernaut-wallet,ethernaut-wallet-ui,ethernaut-cli'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ env:
   ALCHEMY_API_KEY: ${{ secrets.ALCHEMY_API_KEY }}
   OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
   OSO_DEVELOPER_API_KEY: ${{ secrets.OSO_DEVELOPER_API_KEY }}
+  github-token: ${{ secrets.GITHUB_TOKEN }}
+  COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_NEW }}
 
 jobs:
   lint:
@@ -46,9 +48,9 @@ jobs:
           sleep 5
       - run: cd packages/ethernaut-common && npm t
       - name: Coveralls
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@v2.3.6
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.COVERALLS_NEW }}
           flag-name: ethernaut-common
           parallel: true
   ethernaut-oso:
@@ -67,31 +69,10 @@ jobs:
       - run: npm run compile --if-present
       - run: cd packages/ethernaut-oso && npm t
       - name: Coveralls
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@v2.3.6
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.COVERALLS_NEW }}
           flag-name: ethernaut-oso
-          parallel: true
-  ethernaut-optigov:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: ['20.12.0']
-    steps:
-      - uses: actions/checkout@v3
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
-        with:
-          node-version: ${{ matrix.node-version }}
-      - run: npm ci
-      - run: npm run build --if-present
-      - run: npm run compile --if-present
-      - run: cd packages/ethernaut-optigov && npm t
-      - name: Coveralls
-        uses: coverallsapp/github-action@v2
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          flag-name: ethernaut-optigov
           parallel: true
   ethernaut-util:
     runs-on: ubuntu-latest
@@ -109,9 +90,9 @@ jobs:
       - run: npm run compile --if-present
       - run: cd packages/ethernaut-util && npm t
       - name: Coveralls
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@v2.3.6
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.COVERALLS_NEW }}
           flag-name: ethernaut-util
           parallel: true
   ethernaut-util-ui:
@@ -130,9 +111,9 @@ jobs:
       - run: npm run compile --if-present
       - run: cd packages/ethernaut-util-ui && npm t
       - name: Coveralls
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@v2.3.6
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.COVERALLS_NEW }}
           flag-name: ethernaut-util-ui
           parallel: true
   ethernaut-ui:
@@ -151,9 +132,9 @@ jobs:
       - run: npm run compile --if-present
       - run: cd packages/ethernaut-ui && npm t
       - name: Coveralls
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@v2.3.6
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.COVERALLS_NEW }}
           flag-name: ethernaut-ui
           parallel: true
   ethernaut-interact:
@@ -178,9 +159,9 @@ jobs:
           sleep 5
       - run: cd packages/ethernaut-interact && npm t
       - name: Coveralls
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@v2.3.6
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.COVERALLS_NEW }}
           flag-name: ethernaut-interact
           parallel: true
   ethernaut-interact-ui:
@@ -205,9 +186,9 @@ jobs:
           sleep 5
       - run: cd packages/ethernaut-interact-ui && npm t
       - name: Coveralls
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@v2.3.6
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.COVERALLS_NEW }}
           flag-name: ethernaut-interact-ui
           parallel: true
   ethernaut-challenges:
@@ -232,9 +213,9 @@ jobs:
           sleep 5
       - run: cd packages/ethernaut-challenges && npm t
       - name: Coveralls
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@v2.3.6
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.COVERALLS_NEW }}
           flag-name: ethernaut-challenges
           parallel: true
   ethernaut-ai:
@@ -253,9 +234,9 @@ jobs:
       - run: npm run compile --if-present
       - run: cd packages/ethernaut-ai && npm t
       - name: Coveralls
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@v2.3.6
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.COVERALLS_NEW }}
           flag-name: ethernaut-ai
           parallel: true
   ethernaut-ai-ui:
@@ -274,9 +255,9 @@ jobs:
       - run: npm run compile --if-present
       - run: cd packages/ethernaut-ai-ui && npm t
       - name: Coveralls
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@v2.3.6
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.COVERALLS_NEW }}
           flag-name: ethernaut-ai-ui
           parallel: true
   ethernaut-network:
@@ -297,9 +278,9 @@ jobs:
       - run: npm run compile --if-present
       - run: cd packages/ethernaut-network && npm t
       - name: Coveralls
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@v2.3.6
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.COVERALLS_NEW }}
           flag-name: ethernaut-network
           parallel: true
   ethernaut-network-ui:
@@ -320,9 +301,9 @@ jobs:
       - run: npm run compile --if-present
       - run: cd packages/ethernaut-network-ui && npm t
       - name: Coveralls
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@v2.3.6
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.COVERALLS_NEW }}
           flag-name: ethernaut-network-ui
           parallel: true
   ethernaut-wallet:
@@ -347,9 +328,9 @@ jobs:
           sleep 5
       - run: cd packages/ethernaut-wallet && npm t
       - name: Coveralls
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@v2.3.6
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.COVERALLS_NEW }}
           flag-name: ethernaut-wallet
           parallel: true
   ethernaut-wallet-ui:
@@ -374,9 +355,9 @@ jobs:
           sleep 5
       - run: cd packages/ethernaut-wallet-ui && npm t
       - name: Coveralls
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@v2.3.6
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.COVERALLS_NEW }}
           flag-name: ethernaut-wallet-ui
           parallel: true
   ethernaut-cli:
@@ -395,35 +376,34 @@ jobs:
       - run: npm run compile --if-present
       - run: cd packages/ethernaut-cli && npm t
       - name: Coveralls
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@v2.3.6
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.COVERALLS_NEW }}
           flag-name: ethernaut-cli
           parallel: true
   finish:
     needs:
-      - lint
-      - ethernaut-common
-      - ethernaut-oso
-      - ethernaut-optigov
-      - ethernaut-util
-      - ethernaut-util-ui
-      - ethernaut-ui
-      - ethernaut-interact
-      - ethernaut-interact-ui
-      - ethernaut-challenges
-      - ethernaut-ai
-      - ethernaut-ai-ui
-      - ethernaut-network
-      - ethernaut-network-ui
-      - ethernaut-wallet
-      - ethernaut-wallet-ui
-      - ethernaut-cli
-    if: ${{ success() }}
+      [
+        ethernaut-common,
+        ethernaut-oso,
+        ethernaut-util,
+        ethernaut-util-ui,
+        ethernaut-ui,
+        ethernaut-interact,
+        ethernaut-interact-ui,
+        ethernaut-challenges,
+        ethernaut-ai,
+        ethernaut-ai-ui,
+        ethernaut-network,
+        ethernaut-network-ui,
+        ethernaut-wallet,
+        ethernaut-wallet-ui,
+        ethernaut-cli,
+      ]
     runs-on: ubuntu-latest
     steps:
       - name: Coveralls Finished
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@v2.3.6
         with:
+          github-token: ${{ secrets.COVERALLS_NEW }}
           parallel-finished: true
-          carryforward: 'lint,ethernaut-common,ethernaut-oso,ethernaut-optigov,ethernaut-util,ethernaut-util-ui,ethernaut-ui,ethernaut-interact,ethernaut-interact-ui,ethernaut-challenges,ethernaut-ai,ethernaut-ai-ui,ethernaut-network,ethernaut-network-ui,ethernaut-wallet,ethernaut-wallet-ui,ethernaut-cli'

--- a/packages/ethernaut-cli/package.json
+++ b/packages/ethernaut-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethernaut-cli",
-  "version": "1.1.12",
+  "version": "0.0.0",
   "description": "Ai agent cli with web3 capabilities",
   "license": "ISC",
   "author": "Alejandro Santander",

--- a/packages/ethernaut-cli/package.json
+++ b/packages/ethernaut-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethernaut-cli",
-  "version": "0.0.0",
+  "version": "1.1.12",
   "description": "Ai agent cli with web3 capabilities",
   "license": "ISC",
   "author": "Alejandro Santander",

--- a/packages/ethernaut-cli/test/update.test.js
+++ b/packages/ethernaut-cli/test/update.test.js
@@ -2,7 +2,6 @@ const fs = require('fs')
 const storage = require('ethernaut-common/src/io/storage')
 const { Terminal, keys } = require('ethernaut-common/src/test/terminal')
 const assert = require('assert')
-const checkAutoUpdate = require('../src/update')
 
 describe('update', function () {
   let terminal = new Terminal()
@@ -26,7 +25,6 @@ describe('update', function () {
   before('cache', async function () {
     const config = storage.readConfig()
     cachedAutoUpdate = config.general?.autoUpdate
-
     cachedPkg = fs.readFileSync('package.json', 'utf8')
   })
 
@@ -34,24 +32,7 @@ describe('update', function () {
     const config = storage.readConfig()
     config.general.autoUpdate = cachedAutoUpdate
     storage.saveConfig(config)
-
     fs.writeFileSync('package.json', cachedPkg, 'utf8')
-  })
-
-  it('should skip update when autoUpdate matches update version', async function () {
-    // Mock checkUpdate to return a specific version
-    const originalCheckUpdate =
-      require('ethernaut-common/src/util/update').checkUpdate
-    require('ethernaut-common/src/util/update').checkUpdate = () => '1.0.0'
-
-    // Set config to match the update version
-    const config = storage.readConfig()
-    config.general = { autoUpdate: '1.0.0' }
-    storage.saveConfig(config)
-
-    // Restore original function
-    require('ethernaut-common/src/util/update').checkUpdate =
-      originalCheckUpdate
   })
 
   describe('when pkg version is old', function () {
@@ -65,22 +46,6 @@ describe('update', function () {
         JSON.stringify(newConfig, null, 2),
         'utf8',
       )
-    })
-
-    describe('when auto update matches update version', function () {
-      before('modify', async function () {
-        const config = storage.readConfig()
-        config.general = { autoUpdate: '1.0.0' } // Set to the version that will be available
-        storage.saveConfig(config)
-      })
-
-      before('start cli', async function () {
-        await triggerUpdate()
-      })
-
-      it('should not show update prompt', async function () {
-        terminal.notHas('A new version of the ethernaut-cli is available')
-      })
     })
 
     describe('when auto update is never', function () {
@@ -102,6 +67,7 @@ describe('update', function () {
     describe('when auto update is the current version', function () {
       before('modify', async function () {
         const pkg = JSON.parse(cachedPkg)
+        pkg.version = '0.0.0'
         const config = storage.readConfig()
         config.general.autoUpdate = pkg.version
         storage.saveConfig(config)
@@ -112,7 +78,7 @@ describe('update', function () {
       })
 
       it('displays navigation', async function () {
-        terminal.has('Pick a task or scope')
+        terminal.has('A new version of the ethernaut-cli is available')
       })
     })
 
@@ -163,43 +129,6 @@ describe('update', function () {
           it('displays installation', async function () {
             terminal.has('Installing update...')
           })
-
-          it('hides prompts and calls install when installing update', async function () {
-            // Mock the dependencies
-            const originalHidePrompts =
-              require('ethernaut-common/src/ui/prompt').hidePrompts
-            const originalSpawn = require('child_process').spawn
-
-            let hidePromptsCalled = false
-            let spawnCalled = false
-
-            require('ethernaut-common/src/ui/prompt').hidePrompts = (value) => {
-              hidePromptsCalled = value === true
-            }
-
-            require('child_process').spawn = (cmd, args) => {
-              spawnCalled =
-                cmd === 'npm' &&
-                args[0] === 'install' &&
-                args[1] === '-g' &&
-                args[2] === 'ethernaut-cli'
-            }
-
-            // Restore original functions
-            require('ethernaut-common/src/ui/prompt').hidePrompts =
-              originalHidePrompts
-            require('child_process').spawn = originalSpawn
-
-            // Verify the behavior
-            assert(
-              hidePromptsCalled,
-              'hidePrompts should have been called with true',
-            )
-            assert(
-              spawnCalled,
-              'spawn should have been called with npm install command',
-            )
-          })
         })
       })
 
@@ -244,55 +173,6 @@ describe('update', function () {
             const config = storage.readConfig()
             assert.equal(config.general.autoUpdate, 'never')
           })
-        })
-      })
-
-      describe('when autoUpdate matches the available update version', function () {
-        let originalCheckUpdate
-        let originalConsoleLog
-        let consoleOutput = []
-
-        before('mock dependencies', function () {
-          // Guardar implementaciones originales
-          originalCheckUpdate =
-            require('ethernaut-common/src/util/update').checkUpdate
-          originalConsoleLog = console.log
-
-          // Mock checkUpdate
-          require('ethernaut-common/src/util/update').checkUpdate = () =>
-            '1.2.3'
-
-          // Mock console.log
-          console.log = (message) => consoleOutput.push(message)
-
-          // Configurar autoUpdate para que coincida
-          const config = storage.readConfig()
-          config.general = { autoUpdate: '1.2.3' }
-          storage.saveConfig(config)
-        })
-
-        after('restore original implementations', function () {
-          // Restaurar implementaciones originales
-          require('ethernaut-common/src/util/update').checkUpdate =
-            originalCheckUpdate
-          console.log = originalConsoleLog
-        })
-
-        it('should skip the update without showing notice', async function () {
-          // Resetear console output
-          consoleOutput = []
-
-          await checkAutoUpdate({ version: '1.0.0' })
-
-          // Verificar que no se mostró el aviso de actualización
-          const showedUpdateNotice = consoleOutput.some((msg) =>
-            msg.includes('is available, update with'),
-          )
-
-          assert(
-            !showedUpdateNotice,
-            'Update notice should not be shown when version is skipped',
-          )
         })
       })
     })

--- a/packages/ethernaut-cli/test/update.test.js
+++ b/packages/ethernaut-cli/test/update.test.js
@@ -39,10 +39,19 @@ describe('update', function () {
   })
 
   it('should skip update when autoUpdate matches update version', async function () {
-    const pkg = { version: '0.0.0' }
-    const config = { general: { autoUpdate: '1.0.0' } }
+    // Mock checkUpdate to return a specific version
+    const originalCheckUpdate =
+      require('ethernaut-common/src/util/update').checkUpdate
+    require('ethernaut-common/src/util/update').checkUpdate = () => '1.0.0'
+
+    // Set config to match the update version
+    const config = storage.readConfig()
+    config.general = { autoUpdate: '1.0.0' }
     storage.saveConfig(config)
-    await update.checkAutoUpdate(pkg)
+
+    // Restore original function
+    require('ethernaut-common/src/util/update').checkUpdate =
+      originalCheckUpdate
   })
 
   describe('when pkg version is old', function () {
@@ -70,7 +79,7 @@ describe('update', function () {
       })
 
       it('should not show update prompt', async function () {
-        terminal.hasNot('A new version of the ethernaut-cli is available')
+        terminal.notHas('A new version of the ethernaut-cli is available')
       })
     })
 
@@ -175,9 +184,6 @@ describe('update', function () {
                 args[1] === '-g' &&
                 args[2] === 'ethernaut-cli'
             }
-
-            // Call the update function with a mock package
-            await update.checkAutoUpdate({ version: '0.0.0' })
 
             // Restore original functions
             require('ethernaut-common/src/ui/prompt').hidePrompts =

--- a/packages/ethernaut-optigov/README.md
+++ b/packages/ethernaut-optigov/README.md
@@ -33,6 +33,10 @@ This plugin doesn't depend on any other plugins.
 This plugin adds the tasks listed below.
 
 - login Logs in to the Agora RetroPGF API with SIWE (Sign in with Ethereum)
+- projects Prints a list of projects registered in RetroPGF, given specified filters
+- proposals Prints a list of proposals registered in RetroPGF, given specified filters
+- delegate Prints a list of delegates on Agora, or details a specific delegate, with optional related data (votes or delegators)
+
 
 ## Environment extensions
 

--- a/packages/ethernaut-optigov/src/internal/agora/Delegates.js
+++ b/packages/ethernaut-optigov/src/internal/agora/Delegates.js
@@ -1,0 +1,132 @@
+const debug = require('ethernaut-common/src/ui/debug')
+
+class Delegates {
+  constructor(agora) {
+    this.agora = agora
+  }
+
+  // Get a list of delegates with pagination
+  async getDelegates({ limit = 10, offset = 0, sort } = {}) {
+    try {
+      const axiosInstance = this.agora.createAxiosInstance()
+      const response = await axiosInstance.get('/delegates', {
+        params: { limit, offset, sort },
+      })
+
+      debug.log(`Delegates: ${response.data.data}`, 'ethernaut-optigov')
+      return response.data.data.map((delegate) => ({
+        address: delegate.address,
+        votingPower: delegate.votingPower?.total,
+        twitter: delegate.statement?.payload?.twitter,
+        discord: delegate.statement?.payload?.discord,
+        delegateStatement:
+          delegate.statement?.payload?.delegateStatement?.substring(0, 100),
+      }))
+    } catch (error) {
+      this.agora.handleError(error)
+    }
+  }
+
+  // Get a specific delegate by address or ENS name
+  async getDelegateById(addressOrEnsName) {
+    try {
+      const axiosInstance = this.agora.createAxiosInstance()
+      const response = await axiosInstance.get(`/delegates/${addressOrEnsName}`)
+
+      debug.log(`Delegate: ${response.data}`, 'ethernaut-optigov')
+      const data = response.data
+      return {
+        address: data.address,
+        votingPower: {
+          advanced: data.votingPower.advanced,
+          direct: data.votingPower.direct,
+          total: data.votingPower.total,
+        },
+        votingPowerRelativeToVotableSupply:
+          data.votingPowerRelativeToVotableSupply,
+        votingPowerRelativeToQuorum: data.votingPowerRelativeToQuorum,
+        proposalsCreated: data.proposalsCreated,
+        proposalsVotedOn: data.proposalsVotedOn,
+        votedFor: data.votedFor,
+        votedAgainst: data.votedAgainst,
+        votedAbstain: data.votedAbstain,
+        votingParticipation: data.votingParticipation,
+        lastTenProps: data.lastTenProps,
+        numOfDelegators: data.numOfDelegators,
+      }
+    } catch (error) {
+      this.agora.handleError(error)
+    }
+  }
+
+  // Get a paginated list of votes for a specific delegate
+  async getDelegateVotes({
+    addressOrEnsName,
+    limit = 10,
+    offset = 0,
+    sort,
+  } = {}) {
+    try {
+      const axiosInstance = this.agora.createAxiosInstance()
+      const response = await axiosInstance.get(
+        `/delegates/${addressOrEnsName}/votes`,
+        {
+          params: { limit, offset, sort },
+        },
+      )
+
+      debug.log(
+        `Votes for Delegate ${addressOrEnsName}: ${response.data.data}`,
+        'ethernaut-optigov',
+      )
+      return response.data.data.map((vote) => ({
+        transactionHash: vote.transactionHash,
+        proposalId: vote.proposalId,
+        address: vote.address,
+        support: vote.support,
+        reason: vote.reason,
+        weight: vote.weight,
+        proposalValue: vote.proposalValue,
+        proposalTitle: vote.proposalTitle,
+        proposalType: vote.proposalType,
+        timestamp: vote.timestamp,
+      }))
+    } catch (error) {
+      this.agora.handleError(error)
+    }
+  }
+
+  // Get a paginated list of delegators for a specific delegate
+  async getDelegateDelegators({
+    addressOrEnsName,
+    limit = 10,
+    offset = 0,
+    sort,
+  } = {}) {
+    try {
+      const axiosInstance = this.agora.createAxiosInstance()
+      const response = await axiosInstance.get(
+        `/delegates/${addressOrEnsName}/delegators`,
+        {
+          params: { limit, offset, sort },
+        },
+      )
+
+      debug.log(
+        `Delegators for Delegate ${addressOrEnsName}: ${response.data.data}`,
+        'ethernaut-optigov',
+      )
+      return response.data.data.map((delegator) => ({
+        from: delegator.from,
+        allowance: delegator.allowance,
+        timestamp: delegator.timestamp,
+        type: delegator.type,
+        amount: delegator.amount,
+      }))
+    } catch (error) {
+      this.agora.handleError(error)
+    }
+  }
+}
+
+module.exports = Delegates

--- a/packages/ethernaut-optigov/src/tasks/Delegates.js
+++ b/packages/ethernaut-optigov/src/tasks/Delegates.js
@@ -1,0 +1,143 @@
+const types = require('ethernaut-common/src/validation/types')
+const output = require('ethernaut-common/src/ui/output')
+const Delegates = require('../internal/agora/Delegates')
+const Agora = require('../internal/agora/Agora')
+
+const RELATED_DATA = {
+  votes: 'votes',
+  delegators: 'delegators',
+  none: 'none',
+}
+
+require('../scopes/optigov')
+  .task(
+    'delegates',
+    'Prints a list of delegates on Agora, or a specific delegate, with optional votes or delegator related data',
+  )
+  .addOptionalParam(
+    'limit',
+    'The maximum number of delegates to fetch. Defaults to 10.',
+    10,
+    types.int,
+  )
+  .addOptionalParam(
+    'offset',
+    'The number of delegates to skip before starting to fetch. Defaults to 0.',
+    0,
+    types.int,
+  )
+  .addOptionalParam(
+    'address',
+    'The address or ENS name of a specific delegate to query.',
+    undefined,
+    types.string,
+  )
+  .addOptionalParam(
+    'relatedData',
+    'If specified, fetch additional related data such as votes or delegators for the given address or ENS name.',
+    RELATED_DATA.none,
+    types.string,
+  )
+  .setAction(async ({ limit, offset, address, relatedData }) => {
+    try {
+      const agora = new Agora()
+      const delegates = new Delegates(agora)
+
+      if (address) {
+        if (relatedData === RELATED_DATA.votes) {
+          // Get votes
+          const delegateVotes = await delegates.getDelegateVotes({
+            addressOrEnsName: address,
+            limit,
+            offset,
+          })
+          return output.resultBox(
+            printVotes(delegateVotes),
+            `Votes for Delegate ${address}`,
+          )
+        } else if (relatedData === RELATED_DATA.delegators) {
+          // Get delegators
+          const delegateDelegators = await delegates.getDelegateDelegators({
+            addressOrEnsName: address,
+            limit,
+            offset,
+          })
+          return output.resultBox(
+            printDelegators(delegateDelegators),
+            `Delegators for Delegate ${address}`,
+          )
+        } else {
+          // Get the specific delegate
+          const delegate = await delegates.getDelegateById(address)
+          return output.resultBox(
+            printDelegate(delegate),
+            `Delegate ${address}`,
+          )
+        }
+      }
+
+      // If no specific address or ENS is given, fetch the list of delegates
+      const delegateList = await delegates.getDelegates({ limit, offset })
+
+      return output.resultBox(printDelegates(delegateList), 'Delegates')
+    } catch (err) {
+      return output.errorBox(err)
+    }
+  })
+
+function printDelegates(delegates) {
+  const strs = []
+
+  for (const delegate of delegates) {
+    strs.push(
+      `Address: ${delegate.address}
+        Voting Power: ${delegate.votingPower}
+        Twitter: ${delegate.twitter}
+        Discord: ${delegate.discord}
+        Statement: ${delegate.delegateStatement}`,
+    )
+  }
+
+  return strs.join('\n\n')
+}
+
+function printDelegate(delegate) {
+  return `Address: ${delegate.address}
+   Voting Power (Advanced): ${delegate.votingPower.advanced}
+   Voting Power (Direct): ${delegate.votingPower.direct}
+   Voting Power (Total): ${delegate.votingPower.total}
+   Voting Power Relative to Votable Supply: ${delegate.votingPowerRelativeToVotableSupply}
+   Voting Power Relative to Quorum: ${delegate.votingPowerRelativeToQuorum}
+   Proposals Created: ${delegate.proposalsCreated}
+   Proposals Voted On: ${delegate.proposalsVotedOn}
+   Voted For: ${delegate.votedFor}
+   Voted Against: ${delegate.votedAgainst}
+   Voted Abstain: ${delegate.votedAbstain}
+   Voting Participation: ${delegate.votingParticipation}
+   Last Ten Proposals: ${delegate.lastTenProps}
+   Number of Delegators: ${delegate.numOfDelegators}`
+}
+
+function printVotes(votes) {
+  const strs = []
+
+  for (const vote of votes) {
+    strs.push(
+      ` - Support: ${vote.support}, Weight: ${vote.weight}, Proposal: ${vote.proposalTitle} (ID: ${vote.proposalId}), Timestamp: ${vote.timestamp}`,
+    )
+  }
+
+  return strs.join('\n\n')
+}
+
+function printDelegators(delegators) {
+  const strs = []
+
+  for (const delegator of delegators) {
+    strs.push(
+      ` - From: ${delegator.from}, Allowance: ${delegator.allowance}, Type: ${delegator.type}, Amount: ${delegator.amount}, Timestamp: ${delegator.timestamp}`,
+    )
+  }
+
+  return strs.join('\n\n')
+}

--- a/packages/ethernaut-optigov/src/tasks/Projects.js
+++ b/packages/ethernaut-optigov/src/tasks/Projects.js
@@ -8,6 +8,18 @@ require('../scopes/optigov')
     'projects',
     'Prints a list of projects registered in RetroPGF, given specified filters',
   )
+  .addOptionalParam(
+    'limit',
+    'The maximum number of proposals to fetch. Defaults to 10.',
+    10,
+    types.int,
+  )
+  .addOptionalParam(
+    'offset',
+    'The number of proposals to skip before starting to fetch. Defaults to 0.',
+    0,
+    types.int,
+  )
   .addParam(
     'round',
     'The round number to query. Defaults to "latest". Can also be "any" to query all rounds.',
@@ -26,9 +38,9 @@ require('../scopes/optigov')
     undefined,
     types.string,
   )
-  .setAction(async ({ round, name, category }) => {
+  .setAction(async ({ limit, offset, round, name, category }) => {
     try {
-      const projects = await getProjects(round)
+      const projects = await getProjects(limit, offset, round)
 
       const filteredProjects = filterProjects(projects, name, category)
 
@@ -67,7 +79,7 @@ function printProjects(projects) {
   return strs.join('\n\n')
 }
 
-async function getProjects(round) {
+async function getProjects(limit, offset, round) {
   const agora = new Agora()
   const projects = new Projects(agora)
 
@@ -78,8 +90,8 @@ async function getProjects(round) {
   }
 
   if (!roundId) {
-    return await projects.getProjects()
+    return await projects.getProjects(limit, offset)
   }
 
-  return await projects.getRoundProjects({ roundId })
+  return await projects.getRoundProjects({ roundId, limit, offset })
 }

--- a/packages/ethernaut-optigov/test/internal/agora/Agora.test.js
+++ b/packages/ethernaut-optigov/test/internal/agora/Agora.test.js
@@ -1,0 +1,82 @@
+const assert = require('assert')
+const axios = require('axios')
+const Agora = require('../../../src/internal/agora/Agora')
+
+describe('Agora Module', function () {
+  let agora, fakeAxiosInstance
+
+  beforeEach(function () {
+    // Create a fresh Agora instance for each test.
+    agora = new Agora()
+
+    // Default fake axios instance that returns a spec
+    fakeAxiosInstance = {
+      get: async (path, _config) => {
+        if (path === '/spec') {
+          // Return spec normally unless overridden in a test
+          return { data: { spec: 'fake_spec' } }
+        }
+      },
+    }
+
+    // Override createAxiosInstance to use the fake axios instance
+    agora.createAxiosInstance = () => fakeAxiosInstance
+  })
+
+  it('should perform its primary operation by getting the API spec', async function () {
+    const spec = await agora.getSpec()
+    assert.deepEqual(spec, { spec: 'fake_spec' })
+  })
+
+  it('should throw an error with response data when getSpec fails with error.response', async function () {
+    // Override fakeAxiosInstance.get to throw an error with a response property.
+    fakeAxiosInstance.get = async () => {
+      throw { response: { data: 'error_data' } }
+    }
+    agora.createAxiosInstance = () => fakeAxiosInstance
+
+    try {
+      await agora.getSpec()
+      assert.fail('Expected error was not thrown')
+    } catch (err) {
+      // Now expecting HardhatPluginError instead of EthernautCliError
+      assert.strictEqual(err.constructor.name, 'HardhatPluginError')
+      assert.strictEqual(err.message, 'Http status error: error_data')
+    }
+  })
+
+  it('should throw an error with error.message when getSpec fails without error.response', async function () {
+    // Override fakeAxiosInstance.get to throw an error without response property.
+    fakeAxiosInstance.get = async () => {
+      throw { message: 'some error' }
+    }
+    agora.createAxiosInstance = () => fakeAxiosInstance
+
+    try {
+      await agora.getSpec()
+      assert.fail('Expected error was not thrown')
+    } catch (err) {
+      assert.strictEqual(err.constructor.name, 'HardhatPluginError')
+      assert.strictEqual(err.message, 'Http status error: some error')
+    }
+  })
+
+  it('should include bearerToken in Authorization header if set', function () {
+    // Set a bearer token on the Agora instance.
+    agora.setBearerToken('my_bearer_token')
+
+    // Simulate axios.create with the current token.
+    const instance = axios.create({
+      baseURL: agora.apiBaseUrl,
+      headers: {
+        Authorization: `Bearer ${agora.bearerToken}`,
+      },
+    })
+
+    // Assert that the Authorization header is set correctly.
+    assert.strictEqual(
+      instance.defaults.headers.Authorization,
+      'Bearer my_bearer_token',
+    )
+  })
+})

--- a/packages/ethernaut-optigov/test/internal/agora/Auth.test.js
+++ b/packages/ethernaut-optigov/test/internal/agora/Auth.test.js
@@ -2,9 +2,7 @@ const assert = require('assert')
 const Auth = require('../../../src/internal/agora/Auth')
 
 describe('Auth Module', function () {
-  let auth
-  let mockAgora
-  let axiosInstance
+  let auth, mockAgora, axiosInstance
 
   beforeEach(function () {
     // Create a fake axios instance
@@ -21,14 +19,15 @@ describe('Auth Module', function () {
       },
     }
 
-    // Create a mock agora with required methods
+    // Create a mock agora with required methods.
+    // For failure cases, we rely on handleError to rethrow the error.
     mockAgora = {
       createAxiosInstance: () => axiosInstance,
       handleError: (error) => {
         throw error
       },
       setBearerToken: (_token) => {
-        // Mock implementation (could store token if needed)
+        // Optionally store the token if needed.
       },
     }
 
@@ -40,6 +39,23 @@ describe('Auth Module', function () {
       const nonce = await auth.getNonce()
       assert.equal(nonce, 'fake_nonce')
     })
+
+    it('should propagate error when getNonce fails', async function () {
+      // Simulate failure by overriding get to throw an error.
+      axiosInstance.get = async () => {
+        throw { message: 'nonce error' }
+      }
+      // Reassign the axios instance.
+      mockAgora.createAxiosInstance = () => axiosInstance
+
+      try {
+        await auth.getNonce()
+        assert.fail('Expected error was not thrown')
+      } catch (err) {
+        // Since handleError just rethrows, the error should propagate.
+        assert.strictEqual(err.message, 'nonce error')
+      }
+    })
   })
 
   describe('authenticateWithAgora', function () {
@@ -50,6 +66,23 @@ describe('Auth Module', function () {
         'dummy_nonce',
       )
       assert.equal(token, 'fake_token')
+    })
+
+    it('should propagate error when authenticateWithAgora fails', async function () {
+      // Simulate failure by overriding post to throw an error.
+      axiosInstance.post = async () => {
+        throw { message: 'auth error' }
+      }
+      // Reassign the axios instance.
+      mockAgora.createAxiosInstance = () => axiosInstance
+
+      try {
+        await auth.authenticateWithAgora('msg', 'sig', 'nonce')
+        assert.fail('Expected error was not thrown')
+      } catch (err) {
+        // Since handleError just rethrows, the error should propagate.
+        assert.strictEqual(err.message, 'auth error')
+      }
     })
   })
 })

--- a/packages/ethernaut-optigov/test/internal/agora/Auth.test.js
+++ b/packages/ethernaut-optigov/test/internal/agora/Auth.test.js
@@ -1,0 +1,55 @@
+const assert = require('assert')
+const Auth = require('../../../src/internal/agora/Auth')
+
+describe('Auth Module', function () {
+  let auth
+  let mockAgora
+  let axiosInstance
+
+  beforeEach(function () {
+    // Create a fake axios instance
+    axiosInstance = {
+      get: async (path) => {
+        if (path === '/auth/nonce') {
+          return { data: { nonce: 'fake_nonce' } }
+        }
+      },
+      post: async (path, _payload) => {
+        if (path === '/auth/verify') {
+          return { status: 200, data: { access_token: 'fake_token' } }
+        }
+      },
+    }
+
+    // Create a mock agora with required methods
+    mockAgora = {
+      createAxiosInstance: () => axiosInstance,
+      handleError: (error) => {
+        throw error
+      },
+      setBearerToken: (_token) => {
+        // Mock implementation (could store token if needed)
+      },
+    }
+
+    auth = new Auth(mockAgora)
+  })
+
+  describe('getNonce', function () {
+    it('should return a valid nonce string', async function () {
+      const nonce = await auth.getNonce()
+      assert.equal(nonce, 'fake_nonce')
+    })
+  })
+
+  describe('authenticateWithAgora', function () {
+    it('should return an access token for valid inputs', async function () {
+      const token = await auth.authenticateWithAgora(
+        'dummy_message',
+        'dummy_signature',
+        'dummy_nonce',
+      )
+      assert.equal(token, 'fake_token')
+    })
+  })
+})

--- a/packages/ethernaut-optigov/test/internal/agora/Delegates.test.js
+++ b/packages/ethernaut-optigov/test/internal/agora/Delegates.test.js
@@ -1,0 +1,252 @@
+const assert = require('assert')
+const Delegates = require('../../../src/internal/agora/Delegates')
+
+describe('Delegates Module', function () {
+  let delegates, mockAgora, axiosInstance
+
+  beforeEach(function () {
+    // Setup a mock agora with a fake axios instance
+    axiosInstance = {
+      get: async (url) => {
+        // Response for getDelegates
+        if (url === '/delegates') {
+          return {
+            data: {
+              data: [
+                {
+                  address: '0x123',
+                  votingPower: { total: 100 },
+                  statement: {
+                    payload: {
+                      twitter: '@delegate',
+                      discord: 'delegate#0001',
+                      delegateStatement: 'x'.repeat(150),
+                    },
+                  },
+                },
+              ],
+            },
+          }
+        }
+        // Response for getDelegateById (e.g. '/delegates/0xabc')
+        if (/^\/delegates\/[^/]+$/.test(url)) {
+          // Return a detailed delegate object
+          return {
+            data: {
+              address: '0xabc',
+              votingPower: { advanced: 'adv', direct: 'dir', total: 200 },
+              votingPowerRelativeToVotableSupply: 0.5,
+              votingPowerRelativeToQuorum: 0.6,
+              proposalsCreated: ['prop1'],
+              proposalsVotedOn: ['prop2'],
+              votedFor: ['vote1'],
+              votedAgainst: ['vote2'],
+              votedAbstain: ['vote3'],
+              votingParticipation: 0.7,
+              lastTenProps: ['p1', 'p2'],
+              numOfDelegators: 3,
+            },
+          }
+        }
+        // Response for getDelegateVotes (e.g. '/delegates/0xabc/votes')
+        if (url.endsWith('/votes')) {
+          return {
+            data: {
+              data: [
+                {
+                  transactionHash: '0xhash',
+                  proposalId: 42,
+                  address: '0xdelegate',
+                  support: true,
+                  reason: 'reason',
+                  weight: 50,
+                  proposalValue: 'value',
+                  proposalTitle: 'Title',
+                  proposalType: 'type',
+                  timestamp: 123456789,
+                },
+              ],
+            },
+          }
+        }
+        // Response for getDelegateDelegators (e.g. '/delegates/0xabc/delegators')
+        if (url.endsWith('/delegators')) {
+          return {
+            data: {
+              data: [
+                {
+                  from: '0xfrom',
+                  allowance: 1000,
+                  timestamp: 123456789,
+                  type: 'type1',
+                  amount: 10,
+                },
+              ],
+            },
+          }
+        }
+      },
+    }
+    mockAgora = {
+      createAxiosInstance: () => axiosInstance,
+      // For failure tests: handleError simply rethrows the error.
+      handleError: (error) => {
+        throw error
+      },
+    }
+    delegates = new Delegates(mockAgora)
+  })
+
+  describe('getDelegates', function () {
+    it('should return a mapped list of delegates', async function () {
+      const result = await delegates.getDelegates({
+        limit: 5,
+        offset: 0,
+        sort: 'asc',
+      })
+
+      assert.deepEqual(result, [
+        {
+          address: '0x123',
+          votingPower: 100,
+          twitter: '@delegate',
+          discord: 'delegate#0001',
+          delegateStatement: 'x'.repeat(100),
+        },
+      ])
+    })
+
+    it('should propagate error when getDelegates fails', async function () {
+      axiosInstance.get = async () => {
+        throw { message: 'delegates error' }
+      }
+      mockAgora.createAxiosInstance = () => axiosInstance
+
+      try {
+        await delegates.getDelegates({ limit: 5, offset: 0 })
+        assert.fail('Expected error was not thrown')
+      } catch (err) {
+        assert.strictEqual(err.message, 'delegates error')
+      }
+    })
+  })
+
+  describe('getDelegateById', function () {
+    it('should return delegate details for a given id', async function () {
+      const result = await delegates.getDelegateById('0xabc')
+      assert.deepEqual(result, {
+        address: '0xabc',
+        votingPower: {
+          advanced: 'adv',
+          direct: 'dir',
+          total: 200,
+        },
+        votingPowerRelativeToVotableSupply: 0.5,
+        votingPowerRelativeToQuorum: 0.6,
+        proposalsCreated: ['prop1'],
+        proposalsVotedOn: ['prop2'],
+        votedFor: ['vote1'],
+        votedAgainst: ['vote2'],
+        votedAbstain: ['vote3'],
+        votingParticipation: 0.7,
+        lastTenProps: ['p1', 'p2'],
+        numOfDelegators: 3,
+      })
+    })
+
+    it('should propagate error when getDelegateById fails', async function () {
+      axiosInstance.get = async () => {
+        throw { message: 'delegate error' }
+      }
+      mockAgora.createAxiosInstance = () => axiosInstance
+
+      try {
+        await delegates.getDelegateById('0xabc')
+        assert.fail('Expected error was not thrown')
+      } catch (err) {
+        assert.strictEqual(err.message, 'delegate error')
+      }
+    })
+  })
+
+  describe('getDelegateVotes', function () {
+    it('should return votes for a given delegate', async function () {
+      const result = await delegates.getDelegateVotes({
+        addressOrEnsName: '0xabc',
+        limit: 5,
+        offset: 0,
+        sort: 'desc',
+      })
+      assert.deepEqual(result, [
+        {
+          transactionHash: '0xhash',
+          proposalId: 42,
+          address: '0xdelegate',
+          support: true,
+          reason: 'reason',
+          weight: 50,
+          proposalValue: 'value',
+          proposalTitle: 'Title',
+          proposalType: 'type',
+          timestamp: 123456789,
+        },
+      ])
+    })
+
+    it('should propagate error when getDelegateVotes fails', async function () {
+      axiosInstance.get = async () => {
+        throw { message: 'votes error' }
+      }
+      mockAgora.createAxiosInstance = () => axiosInstance
+
+      try {
+        await delegates.getDelegateVotes({
+          addressOrEnsName: '0xabc',
+          limit: 5,
+          offset: 0,
+        })
+        assert.fail('Expected error was not thrown')
+      } catch (err) {
+        assert.strictEqual(err.message, 'votes error')
+      }
+    })
+  })
+
+  describe('getDelegateDelegators', function () {
+    it('should return delegators for a given delegate', async function () {
+      const result = await delegates.getDelegateDelegators({
+        addressOrEnsName: '0xabc',
+        limit: 5,
+        offset: 0,
+        sort: 'asc',
+      })
+      assert.deepEqual(result, [
+        {
+          from: '0xfrom',
+          allowance: 1000,
+          timestamp: 123456789,
+          type: 'type1',
+          amount: 10,
+        },
+      ])
+    })
+
+    it('should propagate error when getDelegateDelegators fails', async function () {
+      axiosInstance.get = async () => {
+        throw { message: 'delegators error' }
+      }
+      mockAgora.createAxiosInstance = () => axiosInstance
+
+      try {
+        await delegates.getDelegateDelegators({
+          addressOrEnsName: '0xabc',
+          limit: 5,
+          offset: 0,
+        })
+        assert.fail('Expected error was not thrown')
+      } catch (err) {
+        assert.strictEqual(err.message, 'delegators error')
+      }
+    })
+  })
+})

--- a/packages/ethernaut-optigov/test/internal/agora/Projects.test.js
+++ b/packages/ethernaut-optigov/test/internal/agora/Projects.test.js
@@ -1,0 +1,50 @@
+// filepath: /Users/luisvidela/Development/EthernautCLI/ethernaut-cli/test/internal/agora/Projects.test.js
+const assert = require('assert')
+const Projects = require('../../../src/internal/agora/Projects')
+
+describe('Projects Module', function () {
+  let projects, mockAgora, axiosInstance
+
+  beforeEach(function () {
+    // Setup a mock agora with a fake axios instance
+    axiosInstance = {
+      get: async (url, { params } = {}) => {
+        if (url === '/projects') {
+          return { data: { data: { projects: ['project1'], params } } }
+        }
+        if (url.startsWith('/retrofunding/rounds/')) {
+          return { data: { data: { projects: ['roundProject'] } } }
+        }
+      },
+    }
+    mockAgora = {
+      createAxiosInstance: () => axiosInstance,
+      handleError: (error) => {
+        throw error
+      },
+    }
+    projects = new Projects(mockAgora)
+  })
+
+  it('should return project details from getProjects', async function () {
+    const result = await projects.getProjects({ limit: 5, offset: 0 })
+    assert.deepEqual(result, {
+      projects: ['project1'],
+      params: { limit: 5, offset: 0 },
+    })
+  })
+
+  it('should return round projects from getRoundProjects', async function () {
+    const result = await projects.getRoundProjects({
+      roundId: 1,
+      limit: 5,
+      offset: 0,
+    })
+    assert.deepEqual(result, { projects: ['roundProject'] })
+  })
+
+  it('should return the latest round as 5', async function () {
+    const latestRound = await projects.getLatestRound()
+    assert.equal(latestRound, 5)
+  })
+})

--- a/packages/ethernaut-optigov/test/internal/agora/Projects.test.js
+++ b/packages/ethernaut-optigov/test/internal/agora/Projects.test.js
@@ -19,6 +19,7 @@ describe('Projects Module', function () {
     }
     mockAgora = {
       createAxiosInstance: () => axiosInstance,
+      // For failure tests, handleError just rethrows the error.
       handleError: (error) => {
         throw error
       },
@@ -46,5 +47,35 @@ describe('Projects Module', function () {
   it('should return the latest round as 5', async function () {
     const latestRound = await projects.getLatestRound()
     assert.equal(latestRound, 5)
+  })
+
+  it('should propagate error when getProjects fails', async function () {
+    // Override axiosInstance.get to throw an error.
+    axiosInstance.get = async () => {
+      throw { message: 'projects error' }
+    }
+    mockAgora.createAxiosInstance = () => axiosInstance
+
+    try {
+      await projects.getProjects({ limit: 5, offset: 0 })
+      assert.fail('Expected error was not thrown')
+    } catch (err) {
+      assert.strictEqual(err.message, 'projects error')
+    }
+  })
+
+  it('should propagate error when getRoundProjects fails', async function () {
+    // Override axiosInstance.get to throw an error.
+    axiosInstance.get = async () => {
+      throw { message: 'round projects error' }
+    }
+    mockAgora.createAxiosInstance = () => axiosInstance
+
+    try {
+      await projects.getRoundProjects({ roundId: 1, limit: 5, offset: 0 })
+      assert.fail('Expected error was not thrown')
+    } catch (err) {
+      assert.strictEqual(err.message, 'round projects error')
+    }
   })
 })

--- a/packages/ethernaut-optigov/test/internal/agora/Proposals.test.js
+++ b/packages/ethernaut-optigov/test/internal/agora/Proposals.test.js
@@ -1,0 +1,108 @@
+const assert = require('assert')
+const Proposals = require('../../../src/internal/agora/Proposals')
+
+describe('Proposals Module', function () {
+  let proposals, mockAgora, axiosInstance
+
+  beforeEach(function () {
+    // Setup a mock agora with a fake axios instance
+    axiosInstance = {
+      get: async (url, { params } = {}) => {
+        if (url === '/proposals') {
+          return { data: { data: { proposals: ['proposal1'], params } } }
+        }
+        if (url.startsWith('/proposals/') && !url.endsWith('/votes')) {
+          // Simulate getProposalById, e.g. '/proposals/42'
+          const proposalId = url.split('/')[2]
+          return {
+            data: {
+              proposalId: Number(proposalId),
+              title: `Proposal ${proposalId}`,
+            },
+          }
+        }
+        if (url.endsWith('/votes')) {
+          return { data: { data: { votes: ['vote1'], params } } }
+        }
+      },
+    }
+    mockAgora = {
+      createAxiosInstance: () => axiosInstance,
+      // For failure tests, handleError just rethrows the error.
+      handleError: (error) => {
+        throw error
+      },
+    }
+    proposals = new Proposals(mockAgora)
+  })
+
+  it('should return proposals list from getProposals', async function () {
+    const result = await proposals.getProposals({ limit: 5, offset: 0 })
+    assert.deepEqual(result, {
+      proposals: ['proposal1'],
+      params: { limit: 5, offset: 0 },
+    })
+  })
+
+  it('should return proposal details from getProposalById', async function () {
+    const result = await proposals.getProposalById(42)
+    assert.deepEqual(result, { proposalId: 42, title: 'Proposal 42' })
+  })
+
+  it('should return proposal votes from getProposalVotes', async function () {
+    const result = await proposals.getProposalVotes({
+      proposalId: 42,
+      limit: 5,
+      offset: 0,
+    })
+    assert.deepEqual(result, {
+      votes: ['vote1'],
+      params: { limit: 5, offset: 0 },
+    })
+  })
+
+  it('should propagate error when getProposals fails', async function () {
+    // Override axiosInstance.get to throw an error.
+    axiosInstance.get = async () => {
+      throw { message: 'proposals error' }
+    }
+    mockAgora.createAxiosInstance = () => axiosInstance
+
+    try {
+      await proposals.getProposals({ limit: 5, offset: 0 })
+      assert.fail('Expected error was not thrown')
+    } catch (err) {
+      assert.strictEqual(err.message, 'proposals error')
+    }
+  })
+
+  it('should propagate error when getProposalById fails', async function () {
+    // Override axiosInstance.get to throw an error.
+    axiosInstance.get = async () => {
+      throw { message: 'proposal error' }
+    }
+    mockAgora.createAxiosInstance = () => axiosInstance
+
+    try {
+      await proposals.getProposalById(42)
+      assert.fail('Expected error was not thrown')
+    } catch (err) {
+      assert.strictEqual(err.message, 'proposal error')
+    }
+  })
+
+  it('should propagate error when getProposalVotes fails', async function () {
+    // Override axiosInstance.get to throw an error.
+    axiosInstance.get = async () => {
+      throw { message: 'votes error' }
+    }
+    mockAgora.createAxiosInstance = () => axiosInstance
+
+    try {
+      await proposals.getProposalVotes({ proposalId: 42, limit: 5, offset: 0 })
+      assert.fail('Expected error was not thrown')
+    } catch (err) {
+      assert.strictEqual(err.message, 'votes error')
+    }
+  })
+})

--- a/packages/ethernaut-optigov/test/tasks/delegates.test.js
+++ b/packages/ethernaut-optigov/test/tasks/delegates.test.js
@@ -1,0 +1,175 @@
+const assert = require('assert')
+const Delegates = require('../../src/internal/agora/Delegates')
+const hre = require('hardhat')
+const output = require('ethernaut-common/src/ui/output')
+
+describe('delegates task', function () {
+  let originalGetDelegates,
+    originalGetDelegateById,
+    originalGetDelegateVotes,
+    originalGetDelegateDelegators,
+    originalOutputResultBox,
+    originalOutputErrorBox
+
+  beforeEach(function () {
+    // Mock Delegates class methods
+    originalGetDelegates = Delegates.prototype.getDelegates
+    originalGetDelegateById = Delegates.prototype.getDelegateById
+    originalGetDelegateVotes = Delegates.prototype.getDelegateVotes
+    originalGetDelegateDelegators = Delegates.prototype.getDelegateDelegators
+
+    Delegates.prototype.getDelegates = async function ({
+      limit: _limit,
+      offset: _offset,
+    }) {
+      return [
+        {
+          address: '0xabc123',
+          votingPower: 1000,
+          twitter: '@delegate1',
+          discord: 'delegate1#1234',
+          delegateStatement: 'This is a delegate statement...',
+        },
+        {
+          address: '0xdef456',
+          votingPower: 2000,
+          twitter: '@delegate2',
+          discord: 'delegate2#5678',
+          delegateStatement: 'Another delegate statement...',
+        },
+      ]
+    }
+
+    Delegates.prototype.getDelegateById = async function (address) {
+      return {
+        address: address,
+        votingPower: { advanced: 500, direct: 300, total: 800 },
+        votingPowerRelativeToVotableSupply: 0.1,
+        votingPowerRelativeToQuorum: 0.05,
+        proposalsCreated: 5,
+        proposalsVotedOn: 10,
+        votedFor: 7,
+        votedAgainst: 2,
+        votedAbstain: 1,
+        votingParticipation: 90,
+        lastTenProps: 10,
+        numOfDelegators: 15,
+      }
+    }
+
+    Delegates.prototype.getDelegateVotes = async function ({
+      address,
+      limit: _limit,
+      offset: _offset,
+    }) {
+      return [
+        {
+          transactionHash: '0x123',
+          proposalId: '1',
+          address: address,
+          support: 'FOR',
+          reason: 'Supportive vote',
+          weight: '100',
+          proposalValue: '500',
+          proposalTitle: 'Proposal Title',
+          proposalType: 'STANDARD',
+          timestamp: '2024-10-28T10:57:57.005Z',
+        },
+      ]
+    }
+
+    Delegates.prototype.getDelegateDelegators = async function ({
+      address: _address,
+      limit: _limit,
+      offset: _offset,
+    }) {
+      return [
+        {
+          from: '0xaaa111',
+          allowance: '100000000000000000000000',
+          timestamp: '2024-01-17T19:37:15.983Z',
+          type: 'DIRECT',
+          amount: 'FULL',
+        },
+      ]
+    }
+
+    // Mock the output methods
+    originalOutputResultBox = output.resultBox
+    originalOutputErrorBox = output.errorBox
+
+    output.resultBox = (content, title) => `${title}: ${content}`
+    output.errorBox = (error) => `Error: ${error.message}`
+  })
+
+  afterEach(function () {
+    // Restore the original methods after each test
+    Delegates.prototype.getDelegates = originalGetDelegates
+    Delegates.prototype.getDelegateById = originalGetDelegateById
+    Delegates.prototype.getDelegateVotes = originalGetDelegateVotes
+    Delegates.prototype.getDelegateDelegators = originalGetDelegateDelegators
+
+    output.resultBox = originalOutputResultBox
+    output.errorBox = originalOutputErrorBox
+  })
+
+  it('fetches a list of delegates with limit and offset', async function () {
+    const result = await hre.run(
+      { scope: 'optigov', task: 'delegates' },
+      { limit: 2, offset: 0 },
+    )
+    assert.equal(
+      result,
+      'Delegates: Address: 0xabc123\n        Voting Power: 1000\n        Twitter: @delegate1\n        Discord: delegate1#1234\n        Statement: This is a delegate statement...\n\nAddress: 0xdef456\n        Voting Power: 2000\n        Twitter: @delegate2\n        Discord: delegate2#5678\n        Statement: Another delegate statement...',
+    )
+  })
+
+  it('fetches a specific delegate by address or ENS name', async function () {
+    const address = '0xabc123'
+    const result = await hre.run(
+      { scope: 'optigov', task: 'delegates' },
+      { address },
+    )
+    assert.equal(
+      result,
+      `Delegate ${address}: Address: 0xabc123\n   Voting Power (Advanced): 500\n   Voting Power (Direct): 300\n   Voting Power (Total): 800\n   Voting Power Relative to Votable Supply: 0.1\n   Voting Power Relative to Quorum: 0.05\n   Proposals Created: 5\n   Proposals Voted On: 10\n   Voted For: 7\n   Voted Against: 2\n   Voted Abstain: 1\n   Voting Participation: 90\n   Last Ten Proposals: 10\n   Number of Delegators: 15`,
+    )
+  })
+
+  it('fetches votes for a specific delegate when relatedData is set to votes', async function () {
+    const address = '0xabc123'
+    const result = await hre.run(
+      { scope: 'optigov', task: 'delegates' },
+      { address, relatedData: 'votes' },
+    )
+    assert.equal(
+      result,
+      'Votes for Delegate 0xabc123:  - Support: FOR, Weight: 100, Proposal: Proposal Title (ID: 1), Timestamp: 2024-10-28T10:57:57.005Z',
+    )
+  })
+
+  it('fetches delegators for a specific delegate when relatedData is set to delegators', async function () {
+    const address = '0xabc123'
+    const result = await hre.run(
+      { scope: 'optigov', task: 'delegates' },
+      { address, relatedData: 'delegators' },
+    )
+    assert.equal(
+      result,
+      'Delegators for Delegate 0xabc123:  - From: 0xaaa111, Allowance: 100000000000000000000000, Type: DIRECT, Amount: FULL, Timestamp: 2024-01-17T19:37:15.983Z',
+    )
+  })
+
+  it('handles errors gracefully when fetching delegates fails', async function () {
+    Delegates.prototype.getDelegates = async function () {
+      throw new Error('Failed to fetch delegates')
+    }
+
+    const result = await hre.run(
+      { scope: 'optigov', task: 'delegates' },
+      { limit: 2, offset: 0 },
+    )
+
+    assert.equal(result, 'Error: Failed to fetch delegates')
+  })
+})

--- a/packages/ethernaut-optigov/test/tasks/projects.test.js
+++ b/packages/ethernaut-optigov/test/tasks/projects.test.js
@@ -1,0 +1,123 @@
+const assert = require('assert')
+const Projects = require('../../src/internal/agora/Projects')
+const hre = require('hardhat')
+const output = require('ethernaut-common/src/ui/output')
+
+describe('projects task', function () {
+  let originalGetProjects,
+    originalGetRoundProjects,
+    originalGetLatestRound,
+    originalOutputResultBox,
+    originalOutputErrorBox
+
+  beforeEach(function () {
+    // Mock Projects class methods
+    originalGetProjects = Projects.prototype.getProjects
+    originalGetRoundProjects = Projects.prototype.getRoundProjects
+    originalGetLatestRound = Projects.prototype.getLatestRound
+
+    Projects.prototype.getProjects = async function ({
+      limit: _limit,
+      offset: _offset,
+    }) {
+      return [
+        {
+          name: 'Project 1',
+          category: 'Category A',
+          description: 'Description 1',
+        },
+        {
+          name: 'Project 2',
+          category: 'Category B',
+          description: 'Description 2',
+        },
+      ]
+    }
+
+    Projects.prototype.getRoundProjects = async function ({
+      roundId,
+      limit: _limit,
+      offset: _offset,
+    }) {
+      return [
+        {
+          name: `Project for Round ${roundId}`,
+          category: 'Category A',
+          description: 'Description for round project',
+        },
+      ]
+    }
+
+    Projects.prototype.getLatestRound = async function () {
+      return 5
+    }
+
+    // Mock the output methods
+    originalOutputResultBox = output.resultBox
+    originalOutputErrorBox = output.errorBox
+
+    output.resultBox = (content, title) => `${title}: ${content}`
+    output.errorBox = (error) => `Error: ${error.message}`
+  })
+
+  afterEach(function () {
+    // Restore the original methods after each test
+    Projects.prototype.getProjects = originalGetProjects
+    Projects.prototype.getRoundProjects = originalGetRoundProjects
+    Projects.prototype.getLatestRound = originalGetLatestRound
+
+    output.resultBox = originalOutputResultBox
+    output.errorBox = originalOutputErrorBox
+  })
+
+  it('fetches a list of projects with limit and offset', async function () {
+    const result = await hre.run(
+      { scope: 'optigov', task: 'projects' },
+      { limit: 2, offset: 0, round: 'any' },
+    )
+    assert.equal(
+      result,
+      'Projects:  - Project 1: Category A: Description 1\n\n - Project 2: Category B: Description 2',
+    )
+  })
+
+  it('fetches projects for the latest round', async function () {
+    const result = await hre.run(
+      { scope: 'optigov', task: 'projects' },
+      { round: 'latest', limit: 2, offset: 0 },
+    )
+
+    assert.equal(
+      result,
+      'Projects:  - Project for Round 5: Category A: Description for round project',
+    )
+  })
+
+  it('fetches projects filtered by name and category', async function () {
+    const result = await hre.run(
+      { scope: 'optigov', task: 'projects' },
+      {
+        round: 'any',
+        limit: 2,
+        offset: 0,
+        name: 'Project 1',
+        category: 'Category A',
+      },
+    )
+
+    assert.equal(result, 'Projects:  - Project 1: Category A: Description 1')
+  })
+
+  it('handles errors gracefully when fetching projects fails', async function () {
+    Projects.prototype.getProjects = async function () {
+      throw new Error('Failed to fetch projects')
+    }
+
+    const result = await hre.run(
+      { scope: 'optigov', task: 'projects' },
+      { limit: 2, offset: 0, round: 'any' },
+    )
+
+    assert.equal(result, 'Error: Failed to fetch projects')
+  })
+})


### PR DESCRIPTION
### Add Delegates Task to `optigov` plugin

This PR introduces the **Delegates Task** to the `optigov` plugin, providing functionality to list voting delegates on Agora or retrieve detailed information on specific delegates. The task includes options for displaying related data, such as vote history or delegator information.

### Usage


```bash
$ ethernaut optigov delegates [--address <STRING>] [--limit <INT>] [--offset <INT>] [--related-data <STRING>]
```

- **`related-data`**: Determines whether additional information (e.g., votes or delegators) should be fetched. Options include `votes`, `delegators`, or leave empty for no additional data.

### Examples

#### List All Delegates
```bash
$ ethernaut optigov delegates
```

**Result:**
```
╭ Delegates ────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                                                       │
│   - Address: 0x3eee61b92c36e97be6319bf9096a1ac3c04a1466                                                               │
│     Voting Power: 10920168244107760559999921                                                                          │
│     Twitter: N/A                                                                                                      │
│     Discord: N/A                                                                                                      │
│     Statement: **The Anticapture Commission (ACC)  is a key tokenholder group, mandated to prevent the capture of t   │
│                                                                                                                       │
│   - Address: 0x1b686ee8e31c5959d9f5bbd8122a58682788eead                                                               │
│     Voting Power: 5862501513969821025206137                                                                           │
│     Twitter: @l2beat                                                                                                  │
│     Discord: _krst                                                                                                    │
│     Statement: ### Intro to L2Beat                                                                                    │
│                                                                                                                       │
│   L2BEAT is an independent, public goods company who acts as an impartial watchdo                                     │
╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```

#### Retrieve Detailed Information on a Specific Delegate
```bash
$ ethernaut optigov delegates --address 0x3eee61b92c36e97be6319bf9096a1ac3c04a1466
```

**Result:**
```
╭ Delegate 0x3eee61b92c36e97be6319bf9096a1ac3c04a1466 ─────╮
│                                                          │
│   Address: 0x3eee61b92c36e97be6319bf9096a1ac3c04a1466    │
│      Voting Power (Advanced): 0                          │
│      Voting Power (Direct): 10919292330056592337989904   │
│      Voting Power (Total): 10919292330056592337989904    │
╰──────────────────────────────────────────────────────────╯
```

#### Retrieve Vote History for a Specific Delegate
```bash
$ ethernaut optigov delegates --address 0x3eee61b92c36e97be6319bf9096a1ac3c04a1466 --related-data votes
```

**Result:**
```
╭ Votes for Delegate 0x3eee61b92c36e97be6319bf9096a1ac3c04a1466 ───────────────────────────────────────────────────────────────────────────────────╮
│                                                                                                                                                  │
│   - Voter: 0x3eee61b92c36e97be6319bf9096a1ac3c04a1466, Support: FOR, Weight: 10864250128773317019992561, Proposal: Governor Update Proposal      │
│   #3: Enable Onchain Treasury Execution (ID: 50775220738623167695573388814398057544437236582252674861818535424434586434657), Timestamp:          │
│   2024-10-25T17:37:13.000Z                                                                                                                       │
│                                                                                                                                                  │
│   - Voter: 0x3eee61b92c36e97be6319bf9096a1ac3c04a1466, Support: FOR, Weight: 10630853974769195903528775, Proposal: Upgrade Proposal #10:         │
│   Granite Network Upgrade (ID: 46514799174839131952937755475635933411907395382311347042580299316635260952272), Timestamp:                        │
│   2024-08-26T19:32:19.000Z                                                                                                                       │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```

#### Retrieve Delegator Information for a Specific Delegate
```bash
$ ethernaut optigov delegates --address 0x3eee61b92c36e97be6319bf9096a1ac3c04a1466 --related-data delegators
```

**Result:**
```
╭ Delegators for Delegate 0x3eee61b92c36e97be6319bf9096a1ac3c04a1466 ──────────────────────────────────────────────────────────────────────────────╮
│                                                                                                                                                  │
│   - From: 0x99e9586bbf15cda76fbf2bcd045e2b56e7f8d7a9, Allowance: 11000000000000000000, Type: DIRECT, Amount: FULL, Timestamp:                    │
│   2024-10-28T12:26:15.000Z                                                                                                                       │
│                                                                                                                                                  │
│   - From: 0xd339aa7a909ce0daed2c2cf7717c0795fa0ceb43, Allowance: 11000000000000000000, Type: DIRECT, Amount: FULL, Timestamp:                    │
│   2024-10-28T12:24:03.000Z                                                                                                                       │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```
