### PR TITLE
Adds OpenAI beta2 headers and fixes function naming

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -403,5 +403,6 @@ jobs:
       - name: Coveralls Finished
         uses: coverallsapp/github-action@v2
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel-finished: true
           carryforward: 'lint,ethernaut-common,ethernaut-oso,ethernaut-util,ethernaut-util-ui,ethernaut-ui,ethernaut-interact,ethernaut-interact-ui,ethernaut-challenges,ethernaut-ai,ethernaut-ai-ui,ethernaut-network,ethernaut-network-ui,ethernaut-wallet,ethernaut-wallet-ui,ethernaut-cli'

--- a/packages/ethernaut-ai/src/internal/assistants/utils/build-tools-spec.js
+++ b/packages/ethernaut-ai/src/internal/assistants/utils/build-tools-spec.js
@@ -12,7 +12,7 @@ module.exports = function buildToolsSpec(hre) {
     tools.push({
       type: 'function',
       function: {
-        name: t.scope ? `${t.scope}.${t.name}` : t.name,
+        name: t.scope ? `${t.scope}_${t.name}` : t.name, // new regex does not allow periods
         description: t._description,
         parameters: collectParameterSpecs(t),
       },

--- a/packages/ethernaut-ai/src/internal/openai.js
+++ b/packages/ethernaut-ai/src/internal/openai.js
@@ -6,6 +6,11 @@ module.exports = function openai() {
   if (!_openai) {
     _openai = new OpenAI({
       apiKey: process.env.OPENAI_API_KEY,
+      requestOptions: {
+        headers: {
+          'OpenAI-Beta': 'assistants=v2',
+        },
+      },
     })
   }
   return _openai

--- a/packages/ethernaut-ai/src/internal/openai.js
+++ b/packages/ethernaut-ai/src/internal/openai.js
@@ -11,7 +11,15 @@ module.exports = function openai() {
           'OpenAI-Beta': 'assistants=v2',
         },
       },
+      defaultHeaders: { 'OpenAI-Beta': 'assistants=v2' },
+      headers: { 'OpenAI-Beta': 'assistants=v2' },
     })
+    _openai.headers = { 'OpenAI-Beta': 'assistants=v2' }
+    _openai.requestOptions = {
+      headers: {
+        'OpenAI-Beta': 'assistants=v2',
+      },
+    }
   }
   return _openai
 }

--- a/packages/ethernaut-ai/test/scopes/ai.test.js
+++ b/packages/ethernaut-ai/test/scopes/ai.test.js
@@ -5,3 +5,33 @@ describe('ai', function () {
     assert.notEqual(hre.scopes['ai'], undefined)
   })
 })
+
+describe('OpenAI Client', () => {
+  let originalEnv
+
+  beforeEach(() => {
+    originalEnv = process.env.OPENAI_API_KEY
+    process.env.OPENAI_API_KEY = 'test-key'
+  })
+
+  afterEach(() => {
+    process.env.OPENAI_API_KEY = originalEnv
+  })
+
+  it('should create an OpenAI instance with the correct configuration', () => {
+    const openaiClient = require('../../src/internal/openai')()
+
+    assert.ok(openaiClient)
+    assert.strictEqual(openaiClient._options.apiKey, 'test-key')
+    assert.deepStrictEqual(openaiClient._options.requestOptions.headers, {
+      'OpenAI-Beta': 'assistants=v2',
+    })
+  })
+
+  it('should reuse the same instance in multiple calls', () => {
+    const firstInstance = require('../../src/internal/openai')()
+    const secondInstance = require('../../src/internal/openai')()
+
+    assert.strictEqual(firstInstance, secondInstance)
+  })
+})

--- a/packages/ethernaut-cli/test/update.test.js
+++ b/packages/ethernaut-cli/test/update.test.js
@@ -127,7 +127,7 @@ describe('update', function () {
             await terminal.input(keys.ENTER, 2000)
           })
 
-          it('displays installation', async function () {
+          it('displays installation message', async function () {
             terminal.has('Installing update...')
           })
         })


### PR DESCRIPTION
This PR adds OpenAI new headers for Beta 2, as Beta 1 was deprecated since last December. Additionally the function naming convention was fixed for using an underscore as separator, instead of period that is not allowed now by their API.

Fixes #45 

![image](https://github.com/user-attachments/assets/cd5d59dc-93f2-47f3-a166-7ea9945fbe79)
